### PR TITLE
Using typedarray internally

### DIFF
--- a/bases/base16.js
+++ b/bases/base16.js
@@ -1,5 +1,11 @@
 'use strict'
-const { Buffer } = require('buffer')
+
+// TODO 2020-05-03: This is slow, but simple
+const fromHex = (hex) => {
+  return new Uint8Array(hexString.match(/.{1,2}/g).map((byte) => {
+    return parseInt(byte, 16)
+  }))
+}
 
 const create = function base16 (alphabet) {
   return {
@@ -10,7 +16,7 @@ const create = function base16 (alphabet) {
           throw new Error('invalid base16 character')
         }
       }
-      return Buffer.from(input, 'hex')
+      return fromHex(input)
     }
   }
 }

--- a/bases/base32.js
+++ b/bases/base32.js
@@ -1,5 +1,4 @@
 'use strict'
-const { Buffer } = require('buffer')
 
 function decode (input, alphabet) {
   input = input.replace(new RegExp('=', 'g'), '')
@@ -21,7 +20,7 @@ function decode (input, alphabet) {
     }
   }
 
-  return Buffer.from(output.buffer)
+  return output
 }
 
 function encode (buffer, alphabet) {

--- a/bases/base64.js
+++ b/bases/base64.js
@@ -1,5 +1,4 @@
 'use strict'
-const { Buffer } = require('buffer')
 
 const create = alphabet => {
   // The alphabet is only used to know:

--- a/cid.js
+++ b/cid.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { Buffer } = require('buffer')
 const withIs = require('class-is')
 
 const readonly = (object, key, value) => {
@@ -14,7 +13,11 @@ module.exports = multiformats => {
     return [code, buff.slice(length)]
   }
   const encode = (version, codec, multihash) => {
-    return Buffer.concat([varint.encode(version), varint.encode(codec), multihash])
+    return Uint8Array.from([
+      ...varint.encode(version),
+      ...varint.encode(codec),
+      ...multihash
+    ])
   }
   class CID {
     constructor (cid, ...args) {

--- a/codecs/json.js
+++ b/codecs/json.js
@@ -1,8 +1,6 @@
-const { Buffer } = require('buffer')
-
 module.exports = {
-  encode: obj => Buffer.from(JSON.stringify(obj)),
-  decode: buff => JSON.parse(buff.toString()),
+  encode: obj => new TextEncoder.encode(JSON.stringify(obj)),
+  decode: buff => JSON.parse(new TextDecoder().decode(buff)),
   name: 'json',
   code: 0x0200
 }

--- a/codecs/json.js
+++ b/codecs/json.js
@@ -1,5 +1,5 @@
 module.exports = {
-  encode: obj => new TextEncoder.encode(JSON.stringify(obj)),
+  encode: obj => new TextEncoder().encode(JSON.stringify(obj)),
   decode: buff => JSON.parse(new TextDecoder().decode(buff)),
   name: 'json',
   code: 0x0200

--- a/codecs/raw.js
+++ b/codecs/raw.js
@@ -1,5 +1,5 @@
 const raw = buff => {
-  if (Object.prototype.toString.call(data) !== '[object Uint8Array]') {
+  if (Object.prototype.toString.call(buff) !== '[object Uint8Array]') {
     throw new Error('Only Uint8Array instances can be used w/ raw codec')
   }
   return buff

--- a/codecs/raw.js
+++ b/codecs/raw.js
@@ -1,7 +1,7 @@
-const { Buffer } = require('buffer')
-
 const raw = buff => {
-  if (!Buffer.isBuffer(buff)) throw new Error('Only buffer instances can be used w/ raw codec')
+  if (Object.prototype.toString.call(data) !== '[object Uint8Array]') {
+    throw new Error('Only Uint8Array instances can be used w/ raw codec')
+  }
   return buff
 }
 

--- a/hashes/sha2-browser.js
+++ b/hashes/sha2-browser.js
@@ -1,5 +1,4 @@
-const { Buffer } = require('buffer')
-const sha = name => async data => Buffer.from(await window.crypto.subtle.digest(name, data))
+const sha = name => async data => Uint8Array.from(await window.crypto.subtle.digest(name, data))
 
 module.exports = [
   {

--- a/hashes/sha2.js
+++ b/hashes/sha2.js
@@ -1,7 +1,11 @@
 const crypto = require('crypto')
 
-const sha256 = async data => crypto.createHash('sha256').update(data).digest().buffer
-const sha512 = async data => crypto.createHash('sha512').update(data).digest().buffer
+const bufferToUint8Array = (buffer) => {
+  return new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength)
+}
+
+const sha256 = async data => bufferToUint8Array(crypto.createHash('sha256').update(data).digest())
+const sha512 = async data => bufferToUint8Array(crypto.createHash('sha512').update(data).digest())
 
 module.exports = [
   {

--- a/hashes/sha2.js
+++ b/hashes/sha2.js
@@ -1,7 +1,7 @@
 const crypto = require('crypto')
 
-const sha256 = async data => crypto.createHash('sha256').update(data).digest()
-const sha512 = async data => crypto.createHash('sha512').update(data).digest()
+const sha256 = async data => crypto.createHash('sha256').update(data).digest().buffer
+const sha512 = async data => crypto.createHash('sha512').update(data).digest().buffer
 
 module.exports = [
   {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const varints = require('varint')
 const createCID = require('./cid')
 
-const Buffer = null
+const { Buffer } = require('buffer')
 
 // From https://stackoverflow.com/questions/38987784/how-to-convert-a-hexadecimal-string-to-uint8array-and-back-in-javascript/50868276#50868276
 const toHex = (data) =>
@@ -30,6 +30,10 @@ const uint8ArrayEquals = (aa, bb) => {
   }
 
   return true
+}
+
+const bufferToUint8Array = (buffer) => {
+  return new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength)
 }
 
 const cache = new Map()
@@ -182,6 +186,32 @@ module.exports = (table = []) => {
   multiformats.multibase = createMultibase()
   multiformats.multihash = createMultihash(multiformats)
   multiformats.CID = createCID(multiformats)
+
+  multiformats.bufferApi = {
+    multicodec: {
+      add,
+      get,
+      encode: (value, id) => {
+        debugger
+        if (Buffer.isBuffer(value)) {
+          value = bufferToUint8Array(value)
+        }
+        const encoded = multiformats.encode(value, id)
+        const encodedBuffer = Buffer.from(encoded)
+        return encodedBuffer
+      },
+      decode: (valueBuffer, id) => {
+        const value = bufferToUint8Array(valueBuffer)
+        const decoded = multiformats.decode(value, id)
+        if (isUint8Array(decoded)) {
+          return Buffer.from(decoded)
+        } else {
+          return decoded
+        }
+      }
+    }
+  }
+
   return multiformats
 }
 module.exports.fromHex = fromHex

--- a/test/test-multicodec.js
+++ b/test/test-multicodec.js
@@ -3,7 +3,7 @@
 const { Buffer } = require('buffer')
 const assert = require('assert')
 const same = assert.deepStrictEqual
-const multiformats = require('../basics')
+const multiformats = require('../basics').bufferApi
 const test = it
 
 const testThrow = (fn, message) => {
@@ -28,7 +28,7 @@ describe('multicodec', () => {
     same(multicodec.decode(buff, 'json'), { hello: 'world' })
   })
   test('raw cannot encode string', () => {
-    testThrow(() => multicodec.encode('asdf', 'raw'), 'Only buffer instances can be used w/ raw codec')
+    testThrow(() => multicodec.encode('asdf', 'raw'), 'Only Uint8Array instances can be used w/ raw codec')
   })
   test('get failure', () => {
     testThrow(() => multicodec.get(true), 'Unknown key type')

--- a/test/test-multihash.js
+++ b/test/test-multihash.js
@@ -33,7 +33,7 @@ const crypto = require('crypto')
 const encode = name => data => crypto.createHash(name).update(data).digest()
 
 describe('multihash', () => {
-  const { multihash } = multiformat(table)
+  const { multihash } = multiformat(table).bufferApi
   multihash.add(require('../hashes/sha2'))
   const { validate } = multihash
 


### PR DESCRIPTION
This PR isn't meant to be merged. I just want to show my idea of having a library that doesn't depend on Node.js Buffers.

I find it important that libraries that are supposed to be used on the Browser move away from Node.js Buffer in favor of using Browser native TypedArrays. This should reduce the bundle size in the long term. I think any new library should at least be able to be used without Node.js Buffers.

This PR shows that idea. I haven't finished it as I don't want to see time wasted. But I think it's enough to show the idea. I made the multicodec and multihash tests pass. Run them via:

     npx mocha test/test-multicodec.js test/test-multihash.js

Of course the Node.js Buffer based API could be the default and the TypedArray one could be a separate export.