### PR TITLE
fix: make cid properties enumerable for deep-eql compat

### DIFF
--- a/cid.js
+++ b/cid.js
@@ -4,7 +4,11 @@ const { Buffer } = require('buffer')
 const withIs = require('class-is')
 
 const readonly = (object, key, value) => {
-  Object.defineProperty(object, key, { value, writable: false })
+  Object.defineProperty(object, key, {
+    value,
+    writable: false,
+    enumerable: true
+  })
 }
 
 module.exports = multiformats => {

--- a/test/test-cid.js
+++ b/test/test-cid.js
@@ -209,6 +209,11 @@ describe('CID', () => {
 
       assert.ok(CID.isCID(new CID(h1).toV1()))
     })
+
+    test('works with deepEquals', () => {
+      assert.deepStrictEqual(new CID(h1), new CID(h1))
+      assert.notDeepStrictEqual(new CID(h1), new CID(h2))
+    })
   })
 
   describe('throws on invalid inputs', () => {


### PR DESCRIPTION
Found that my entirely different CIDs were still passing `deepEqual()`! Properties need to be enumerable. This is chai using a `for ... in`: https://github.com/chaijs/deep-eql/blob/fa5c6042e5c127df12e1f3ee4b9f9b3e2302864c/index.js#L374-L380, Node.js `assert` relies on `Object.keys()`.