### PR TITLE
feat: Remove Buffer dependency, use Uint8Array

### DIFF
--- a/bases/_base64-browser.js
+++ b/bases/_base64-browser.js
@@ -1,0 +1,1 @@
+module.exports = b => btoa([].reduce.call(b, (p,c) => p + String.fromCharCode(c),''))

--- a/bases/_base64-browser.js
+++ b/bases/_base64-browser.js
@@ -1,1 +1,3 @@
-module.exports = b => btoa([].reduce.call(b, (p,c) => p + String.fromCharCode(c),''))
+/* globals btoa, atob */
+exports.encode = b => btoa([].reduce.call(b, (p, c) => p + String.fromCharCode(c), ''))
+exports.decode = str => Uint8Array.from(atob(str), c => c.charCodeAt(0))

--- a/bases/_base64.js
+++ b/bases/_base64.js
@@ -1,1 +1,3 @@
-module.exports = o => Buffer.from(o).toString('base64')
+const { coerce } = require('../bytes')
+exports.encode = o => Buffer.from(o).toString('base64')
+exports.decode = s => coerce(Buffer.from(s, 'base64'))

--- a/bases/_base64.js
+++ b/bases/_base64.js
@@ -1,0 +1,1 @@
+module.exports = o => Buffer.from(o).toString('base64')

--- a/bases/base16.js
+++ b/bases/base16.js
@@ -1,9 +1,10 @@
 'use strict'
 const { fromHex } = require('../bytes')
+const bytes = require('../bytes')
 
 const create = function base16 (alphabet) {
   return {
-    encode: input => input.toString('hex'),
+    encode: input => bytes.toHex(input),
     decode (input) {
       for (const char of input) {
         if (alphabet.indexOf(char) < 0) {

--- a/bases/base16.js
+++ b/bases/base16.js
@@ -1,11 +1,5 @@
 'use strict'
-
-// TODO 2020-05-03: This is slow, but simple
-const fromHex = (hex) => {
-  return new Uint8Array(hexString.match(/.{1,2}/g).map((byte) => {
-    return parseInt(byte, 16)
-  }))
-}
+const { fromHex } = require('../bytes')
 
 const create = function base16 (alphabet) {
   return {

--- a/bases/base58.js
+++ b/bases/base58.js
@@ -1,7 +1,16 @@
 'use strict'
 const baseX = require('base-x')
+const bytes = require('../bytes')
+
+const wrap = obj => ({
+  encode: b => obj.encode(Buffer.from(b)),
+  decode: s => bytes.coerce(obj.decode(s))
+})
+
+const btc = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+const flickr = '123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ'
 
 module.exports = [
-  { name: 'base58btc', prefix: 'z', ...baseX('123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz') },
-  { name: 'base58flickr', prefix: 'Z', ...baseX('123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ') }
+  { name: 'base58btc', prefix: 'z', ...wrap(baseX(btc)) },
+  { name: 'base58flickr', prefix: 'Z', ...wrap(baseX(flickr)) }
 ]

--- a/bases/base58.js
+++ b/bases/base58.js
@@ -1,6 +1,7 @@
 'use strict'
 const baseX = require('base-x')
 const bytes = require('../bytes')
+const { Buffer } = require('buffer')
 
 const wrap = obj => ({
   encode: b => obj.encode(Buffer.from(b)),

--- a/bases/base64.js
+++ b/bases/base64.js
@@ -1,5 +1,4 @@
 'use strict'
-const { fromString } = require('../bytes')
 const b64 = require('./_base64')
 
 const create = alphabet => {
@@ -13,7 +12,7 @@ const create = alphabet => {
 
   return {
     encode (input) {
-      let output = b64(input)
+      let output = b64.encode(input)
 
       if (url) {
         output = output.replace(/\+/g, '-').replace(/\//g, '_')
@@ -33,7 +32,7 @@ const create = alphabet => {
         }
       }
 
-      return fromString(input, 'base64')
+      return b64.decode(input)
     }
   }
 }

--- a/bases/base64.js
+++ b/bases/base64.js
@@ -1,5 +1,6 @@
 'use strict'
 const { fromString } = require('../bytes')
+const b64 = require('./_base64')
 
 const create = alphabet => {
   // The alphabet is only used to know:
@@ -12,7 +13,7 @@ const create = alphabet => {
 
   return {
     encode (input) {
-      let output = input.toString('base64')
+      let output = b64(input)
 
       if (url) {
         output = output.replace(/\+/g, '-').replace(/\//g, '_')

--- a/bases/base64.js
+++ b/bases/base64.js
@@ -1,4 +1,5 @@
 'use strict'
+const { fromString } = require('../bytes')
 
 const create = alphabet => {
   // The alphabet is only used to know:
@@ -31,7 +32,7 @@ const create = alphabet => {
         }
       }
 
-      return Buffer.from(input, 'base64')
+      return fromString(input, 'base64')
     }
   }
 }

--- a/bytes.js
+++ b/bytes.js
@@ -1,0 +1,54 @@
+/*
+// From https://stackoverflow.com/questions/38987784/how-to-convert-a-hexadecimal-string-to-uint8array-and-back-in-javascript/50868276#50868276
+const toHex = (data) => {
+  return data.reduce((hex, byte) => hex + byte.toString(16).padStart(2, '0'), '')
+}
+// TODO 2020-05-03: This is slow, but simple
+const isUint8Array = (data) => {
+  return Object.prototype.toString.call(data) === '[object Uint8Array]'
+}
+*/
+
+const fromHex = hex => new Uint8Array(hex.match(/.{1,2}/g).map(b => parseInt(b, 16)))
+
+const equals = (aa, bb) => {
+  if (aa.byteLength !== bb.byteLength) {
+    return false
+  }
+
+  for (let ii = 0; ii < aa.byteLength; ii++) {
+    if (aa[ii] !== bb[ii]) {
+      return false
+    }
+  }
+
+  return true
+}
+
+const TypedArray = Object.getPrototypeOf(Int8Array)
+const isTypedArray = obj => obj instanceof TypedArray
+
+const coerce = o => {
+  if (o instanceof Uint8Array && o.constructor.name === 'Uint8Array') return o
+  if (o instanceof DataView) return o.getUint8()
+  if (o instanceof ArrayBuffer) return new Uint8Array(o.buffer)
+  if (isTypedArray(o)) {
+    return new Uint8Array(o.buffer, o.byteOffset, o.byteLength)
+  }
+  throw new Error('Unknown type, must be binary type')
+}
+
+const isBinary = o => {
+  if (o instanceof DataView) return true
+  if (o instanceof ArrayBuffer) return true
+  if (isTypedArray(o)) return true
+  return false
+}
+
+const fromString = str => (new TextEncoder()).encode(str)
+
+exports.equals = equals
+exports.coerce = coerce
+exports.isBinary = isBinary
+exports.fromHex = fromHex
+exports.fromString = fromString

--- a/bytes.js
+++ b/bytes.js
@@ -5,6 +5,7 @@ const fromHex = hex => {
 }
 
 const equals = (aa, bb) => {
+  if (aa === bb) return true
   if (aa.byteLength !== bb.byteLength) {
     return false
   }

--- a/bytes.js
+++ b/bytes.js
@@ -1,15 +1,8 @@
-/*
-// From https://stackoverflow.com/questions/38987784/how-to-convert-a-hexadecimal-string-to-uint8array-and-back-in-javascript/50868276#50868276
-const toHex = (data) => {
-  return data.reduce((hex, byte) => hex + byte.toString(16).padStart(2, '0'), '')
+const toHex = d => d.reduce((hex, byte) => hex + byte.toString(16).padStart(2, '0'), '')
+const fromHex = hex => {
+  if (!hex.length) return new Uint8Array(0)
+  return new Uint8Array(hex.match(/.{1,2}/g).map(b => parseInt(b, 16)))
 }
-// TODO 2020-05-03: This is slow, but simple
-const isUint8Array = (data) => {
-  return Object.prototype.toString.call(data) === '[object Uint8Array]'
-}
-*/
-
-const fromHex = hex => new Uint8Array(hex.match(/.{1,2}/g).map(b => parseInt(b, 16)))
 
 const equals = (aa, bb) => {
   if (aa.byteLength !== bb.byteLength) {
@@ -51,4 +44,5 @@ exports.equals = equals
 exports.coerce = coerce
 exports.isBinary = isBinary
 exports.fromHex = fromHex
+exports.toHex = toHex
 exports.fromString = fromString

--- a/bytes.js
+++ b/bytes.js
@@ -1,7 +1,7 @@
 const toHex = d => d.reduce((hex, byte) => hex + byte.toString(16).padStart(2, '0'), '')
 const fromHex = hex => {
   if (!hex.length) return new Uint8Array(0)
-  return new Uint8Array(hex.match(/.{1,2}/g).map(b => parseInt(b, 16)))
+  return new Uint8Array(hex.match(/../g).map(b => parseInt(b, 16)))
 }
 
 const equals = (aa, bb) => {

--- a/bytes.js
+++ b/bytes.js
@@ -23,9 +23,8 @@ const isTypedArray = obj => obj instanceof TypedArray
 
 const coerce = o => {
   if (o instanceof Uint8Array && o.constructor.name === 'Uint8Array') return o
-  if (o instanceof DataView) return o.getUint8()
-  if (o instanceof ArrayBuffer) return new Uint8Array(o.buffer)
-  if (isTypedArray(o)) {
+  if (o instanceof ArrayBuffer) return new Uint8Array(o)
+  if (o instanceof DataView || isTypedArray(o)) {
     return new Uint8Array(o.buffer, o.byteOffset, o.byteLength)
   }
   throw new Error('Unknown type, must be binary type')

--- a/cid.js
+++ b/cid.js
@@ -18,7 +18,11 @@ module.exports = multiformats => {
   }
   class CID {
     constructor (cid, ...args) {
-      this._baseCache = new Map()
+      Object.defineProperty(this, '_baseCache', {
+        value: new Map(),
+        writable: false,
+        enumerable: false
+      })
       if (_CID.isCID(cid)) {
         readonly(this, 'version', cid.version)
         readonly(this, 'multihash', cid.multihash)

--- a/cid.js
+++ b/cid.js
@@ -135,7 +135,7 @@ module.exports = multiformats => {
     equals (other) {
       return this.code === other.code &&
         this.version === other.version &&
-        this.multihash.equals(other.multihash)
+        bytes.equals(this.multihash, other.multihash)
     }
   }
 

--- a/cid.js
+++ b/cid.js
@@ -1,5 +1,5 @@
 'use strict'
-
+const bytes = require('./bytes')
 const withIs = require('class-is')
 
 const readonly = (object, key, value) => {
@@ -21,15 +21,11 @@ module.exports = multiformats => {
   }
   class CID {
     constructor (cid, ...args) {
-      Object.defineProperty(this, '_baseCache', {
-        value: new Map(),
-        writable: false,
-        enumerable: false
-      })
+      readonly(this, '_baseCache', new Map())
       if (_CID.isCID(cid)) {
         readonly(this, 'version', cid.version)
-        readonly(this, 'multihash', cid.multihash)
-        readonly(this, 'buffer', cid.buffer)
+        readonly(this, 'multihash', bytes.coerce(cid.multihash))
+        readonly(this, 'buffer', bytes.coerce(cid.buffer))
         if (cid.code) readonly(this, 'code', cid.code)
         else readonly(this, 'code', multiformats.get(cid.codec).code)
         return
@@ -60,6 +56,7 @@ module.exports = multiformats => {
         this._baseCache.set(name, cid)
         cid = multibase.decode(cid)
       }
+      cid = bytes.coerce(cid)
       readonly(this, 'buffer', cid)
       let code
       ;[code, cid] = parse(cid)
@@ -119,7 +116,7 @@ module.exports = multiformats => {
           throw new Error(`Cannot string encode V0 in ${base} encoding`)
         }
         const { encode } = multibase.get('base58btc')
-        return encode(this.buffer, 'base58btc')
+        return encode(this.buffer)
       }
       if (!base) base = 'base32'
       if (this._baseCache.has(base)) return this._baseCache.get(base)

--- a/codecs/raw.js
+++ b/codecs/raw.js
@@ -1,9 +1,6 @@
-const raw = buff => {
-  if (Object.prototype.toString.call(buff) !== '[object Uint8Array]') {
-    throw new Error('Only Uint8Array instances can be used w/ raw codec')
-  }
-  return buff
-}
+const { coerce } = require('../bytes')
+
+const raw = buff => coerce(buff)
 
 module.exports = {
   encode: raw,

--- a/hashes/sha2-browser.js
+++ b/hashes/sha2-browser.js
@@ -1,4 +1,4 @@
-const sha = name => async data => Uint8Array.from(await window.crypto.subtle.digest(name, data))
+const sha = name => async data => new Uint8Array(await window.crypto.subtle.digest(name, data))
 
 module.exports = [
   {

--- a/index.js
+++ b/index.js
@@ -91,6 +91,7 @@ const createMultibase = () => {
     if (typeof string !== 'string') throw new Error('Can only multibase decode strings')
     const prefix = string[0]
     string = string.slice(1)
+    if (string.length === 0) return new Uint8Array(0)
     const { decode } = get(prefix)
     return decode(string)
   }

--- a/legacy.js
+++ b/legacy.js
@@ -2,18 +2,21 @@ const CID = require('cids')
 const bytes = require('./bytes')
 const { Buffer } = require('buffer')
 
-const toLegacy = obj => {
-  if (CID.isCID(obj)) return new CID(obj)
-  if (bytes.isBinary(obj)) return Buffer.from(obj)
-  if (obj && typeof obj === 'object') {
-    for (const [key, value] of Object.entries(obj)) {
-      obj[key] = toLegacy(value)
-    }
-  }
-  return obj
-}
-
 const legacy = (multiformats, name) => {
+  const toLegacy = obj => {
+    if (CID.isCID(obj)) {
+      if (!obj.code) return obj
+      const { name } = multiformats.multicodec.get(obj.code)
+      return new CID(obj.version, name, Buffer.from(obj.multihash))
+    }
+    if (bytes.isBinary(obj)) return Buffer.from(obj)
+    if (obj && typeof obj === 'object') {
+      for (const [key, value] of Object.entries(obj)) {
+        obj[key] = toLegacy(value)
+      }
+    }
+    return obj
+  }
   const fromLegacy = obj => {
     if (CID.isCID(obj)) return new multiformats.CID(obj)
     if (bytes.isBinary(obj)) return bytes.coerce(obj)
@@ -25,7 +28,7 @@ const legacy = (multiformats, name) => {
     return obj
   }
   const format = multiformats.multicodec.get(name)
-  const serialize = o => toLegacy(format.encode(fromLegacy(o)))
+  const serialize = o => Buffer.from(format.encode(fromLegacy(o)))
   const deserialize = b => toLegacy(format.decode(bytes.coerce(b)))
   const cid = async (buff, opts) => {
     const defaults = { cidVersion: 1, hashAlg: 'sha2-256' }

--- a/legacy.js
+++ b/legacy.js
@@ -1,15 +1,37 @@
 const CID = require('cids')
+const bytes = require('./bytes')
 const { Buffer } = require('buffer')
 
+const toLegacy = obj => {
+  if (CID.isCID(obj)) return new CID(obj)
+  if (bytes.isBinary(obj)) return Buffer.from(obj)
+  if (obj && typeof obj === 'object') {
+    for (const [key, value] of Object.entries(obj)) {
+      obj[key] = toLegacy(value)
+    }
+  }
+  return obj
+}
+
 const legacy = (multiformats, name) => {
+  const fromLegacy = obj => {
+    if (CID.isCID(obj)) return new multiformats.CID(obj)
+    if (bytes.isBinary(obj)) return bytes.coerce(obj)
+    if (obj && typeof obj === 'object') {
+      for (const [key, value] of Object.entries(obj)) {
+        obj[key] = fromLegacy(value)
+      }
+    }
+    return obj
+  }
   const format = multiformats.multicodec.get(name)
-  const serialize = format.encode
-  const deserialize = format.decode
+  const serialize = o => toLegacy(format.encode(fromLegacy(o)))
+  const deserialize = b => toLegacy(format.decode(bytes.coerce(b)))
   const cid = async (buff, opts) => {
     const defaults = { cidVersion: 1, hashAlg: 'sha2-256' }
     const { cidVersion, hashAlg } = { ...defaults, ...opts }
     const hash = await multiformats.multihash.hash(buff, hashAlg)
-    return new CID(cidVersion, name, hash)
+    return new CID(cidVersion, name, Buffer.from(hash))
   }
   const resolve = (buff, path) => {
     let value = format.decode(buff)

--- a/legacy.js
+++ b/legacy.js
@@ -1,4 +1,5 @@
 const CID = require('cids')
+const { Buffer } = require('buffer')
 
 const legacy = (multiformats, name) => {
   const format = multiformats.multicodec.get(name)

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "standard": "^14.3.3"
   },
   "dependencies": {
-    "cids": "^0.8.0",
     "base-x": "^3.0.8",
     "buffer": "^5.6.0",
+    "cids": "^0.8.0",
     "class-is": "^1.1.0",
     "varint": "^5.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -17,13 +17,13 @@
     "./hashes/sha2.js": "./hashes/sha2-browser.js"
   },
   "devDependencies": {
-    "cids": "^0.8.0",
     "hundreds": "0.0.2",
     "mocha": "^7.1.1",
     "polendina": "^1.0.0",
     "standard": "^14.3.3"
   },
   "dependencies": {
+    "cids": "^0.8.0",
     "base-x": "^3.0.8",
     "buffer": "^5.6.0",
     "class-is": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "js-multiformats",
+  "name": "multiformats",
   "version": "0.0.0",
   "description": "",
   "main": "index.js",
@@ -7,7 +7,7 @@
     "pre:test": "standard",
     "test:node": "hundreds mocha test/test-*.js",
     "test:browser": "polendina --cleanup test/test-*.js",
-    "test": "npm run test:node && npm run test:browser",
+    "test": "npm run pre:test && npm run test:node && npm run test:browser",
     "coverage": "nyc --reporter=html mocha test/test-*.js && npx st -d coverage -p 8080"
   },
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "author": "Mikeal Rogers <mikeal.rogers@gmail.com> (https://www.mikealrogers.com/)",
   "license": "(Apache-2.0 AND MIT)",
   "browser": {
-    "./hashes/sha2.js": "./hashes/sha2-browser.js"
+    "./hashes/sha2.js": "./hashes/sha2-browser.js",
+    "./bases/_base64.js": "./bases/_base64-browser.js"
   },
   "devDependencies": {
     "hundreds": "0.0.2",

--- a/test/test-bytes.js
+++ b/test/test-bytes.js
@@ -1,5 +1,5 @@
 /* globals describe, it */
-test = it
+const test = it
 const bytes = require('../bytes')
 const assert = require('assert')
 const same = assert.deepStrictEqual

--- a/test/test-bytes.js
+++ b/test/test-bytes.js
@@ -1,0 +1,21 @@
+/* globals describe, it */
+test = it
+const bytes = require('../bytes')
+const assert = require('assert')
+const same = assert.deepStrictEqual
+
+describe('bytes', () => {
+  test('isBinary', () => {
+    same(bytes.isBinary(new ArrayBuffer()), true)
+    same(bytes.isBinary(new DataView(new ArrayBuffer())), true)
+  })
+  test('coerce', () => {
+    const fixture = bytes.fromString('test')
+    same(bytes.coerce(fixture.buffer), fixture)
+    same(bytes.coerce(new DataView(fixture.buffer)), fixture)
+  })
+  test('equals', () => {
+    const fixture = bytes.fromString('test')
+    same(bytes.equals(fixture, bytes.fromString('asdfadf')), false)
+  })
+})

--- a/test/test-cid.js
+++ b/test/test-cid.js
@@ -5,9 +5,7 @@ const OLDCID = require('cids')
 const test = it
 const assert = require('assert')
 const same = assert.deepStrictEqual
-const toHex = (data) => {
-  return data.reduce((hex, byte) => hex + byte.toString(16).padStart(2, '0'), '')
-}
+const { toHex } = require('../bytes')
 
 const testThrow = async (fn, message) => {
   try {

--- a/test/test-cid.js
+++ b/test/test-cid.js
@@ -5,6 +5,9 @@ const OLDCID = require('cids')
 const test = it
 const assert = require('assert')
 const same = assert.deepStrictEqual
+const toHex = (data) => {
+  return data.reduce((hex, byte) => hex + byte.toString(16).padStart(2, '0'), '')
+}
 
 const testThrow = async (fn, message) => {
   try {
@@ -98,7 +101,7 @@ describe('CID', () => {
       const cid = new CID(0, codec, hash)
       const buffer = cid.buffer
       assert.ok(buffer)
-      const str = buffer.toString('hex')
+      const str = toHex(buffer)
       same(str, '1220ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad')
     })
 
@@ -167,7 +170,7 @@ describe('CID', () => {
       const cid = new CID(1, code, hash)
       const buffer = cid.buffer
       assert.ok(buffer)
-      const str = buffer.toString('hex')
+      const str = toHex(buffer)
       same(str, '01711220ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad')
     })
 
@@ -321,7 +324,7 @@ describe('CID', () => {
     assert.ok(OLDCID.isCID(cid))
   })
   test('new CID from old CID', () => {
-    const cid = new CID(new OLDCID(1, 'raw', hash))
+    const cid = new CID(new OLDCID(1, 'raw', Buffer.from(hash)))
     same(cid.version, 1)
     same(cid.multihash, hash)
     same(cid.code, 85)

--- a/test/test-errors.js
+++ b/test/test-errors.js
@@ -1,0 +1,16 @@
+/* globals describe, it */
+'use strict'
+const assert = require('assert')
+const multiformat = require('../')()
+const test = it
+
+describe('errors and type checking', () => {
+  test('add argument validation', () => {
+    assert.throws(() => multiformat.add())
+    assert.throws(() => multiformat.add({ code: 'nope' }), /.*integer code.*/)
+    assert.throws(() => multiformat.add({ code: 200, name: () => {} }), /.*string name.*/)
+    assert.throws(() => multiformat.add({ code: 200, name: 'blip', encode: false }), /.*encode .* function.*/)
+    assert.throws(() => multiformat.add({ code: 200, name: 'blip', encode: () => {}, decode: 'nope' }), /.*decode .* function.*/)
+    assert.doesNotThrow(() => multiformat.add({ code: 200, name: 'blip', encode: () => {}, decode: () => {} }))
+  })
+})

--- a/test/test-legacy.js
+++ b/test/test-legacy.js
@@ -32,7 +32,7 @@ describe('multicodec', () => {
       encode: o => {
         if (o.link) {
           assert.ok(o.link.code)
-          o.link = 'test'
+          o.link = true
         }
         return json.util.serialize({ o, l: link.toString() })
       },
@@ -82,7 +82,7 @@ describe('multicodec', () => {
     const fixture = custom.util.serialize({
       one: {
         two: {
-          hello: 'world',
+          hello: 'world'
         },
         three: 3
       }
@@ -93,9 +93,9 @@ describe('multicodec', () => {
     same(arr(json.resolver.tree(json.util.serialize('asdf'))), [])
   })
   test('cid API change', () => {
-    const fixture = custom.util.serialize({ link: new multiformats.CID(link) })
+    const fixture = { link }
     const buff = custom.util.serialize(fixture)
-    const decoded = custom.util.deserialize(fixture)
+    const decoded = custom.util.deserialize(buff)
     same(decoded.link, link)
   })
 })

--- a/test/test-legacy.js
+++ b/test/test-legacy.js
@@ -23,7 +23,7 @@ describe('multicodec', async () => {
   multiformats.multicodec.add({
     name: 'custom',
     code: 6787678,
-    encode: o => json.util.serialize({o, l: link.toString() }),
+    encode: o => json.util.serialize({ o, l: link.toString() }),
     decode: buff => {
       const obj = json.util.deserialize(buff)
       obj.l = link
@@ -68,6 +68,6 @@ describe('multicodec', async () => {
     const arr = a => Array.from(a)
     const links = ['/o', '/o/one', '/o/one/two', '/o/one/two/hello', '/o/one/three', '/l']
     same(arr(custom.resolver.tree(fixture)), links)
-    same(arr(json.resolver.tree(json.util.serialize("asdf"))), [])
+    same(arr(json.resolver.tree(json.util.serialize('asdf'))), [])
   })
 })

--- a/test/test-multibase.js
+++ b/test/test-multibase.js
@@ -1,6 +1,6 @@
 /* globals describe, it */
 'use strict'
-const { Buffer } = require('buffer')
+const bytes = require('../bytes')
 const assert = require('assert')
 const same = assert.deepStrictEqual
 const multiformat = require('../')
@@ -23,26 +23,26 @@ describe('multibase', () => {
   multibase.add(require('../bases/base58'))
   multibase.add(require('../bases/base64'))
 
-  describe('basics', () => {
-    for (const base of ['base16', 'base32', 'base58btc', 'base64']) {
+  for (const base of ['base16', 'base32', 'base58btc', 'base64']) {
+    describe(`basics ${base}`, () => {
       test('encode/decode', () => {
-        const string = multibase.encode(Buffer.from('test'), base)
+        const string = multibase.encode(bytes.fromString('test'), base)
         same(string[0], multibase.get(base).prefix)
         const buffer = multibase.decode(string)
-        same(buffer, Buffer.from('test'))
+        same(buffer, bytes.fromString('test'))
       })
       test('empty', () => {
-        const str = multibase.encode(Buffer.from(''), base)
+        const str = multibase.encode(bytes.fromString(''), base)
         same(str, multibase.get(base).prefix)
-        same(multibase.decode(str), Buffer.from(''))
+        same(multibase.decode(str), bytes.fromString(''))
       })
       test('bad chars', () => {
         const str = multibase.get(base).prefix + '#$%^&*&^%$#'
         const msg = base === 'base58btc' ? 'Non-base58 character' : `invalid ${base} character`
         testThrow(() => multibase.decode(str), msg)
       })
-    }
-  })
+    })
+  }
 
   test('get fails', () => {
     let msg = 'Missing multibase implementation for "x"'
@@ -51,14 +51,14 @@ describe('multibase', () => {
     testThrow(() => multibase.get('notfound'), msg)
   })
   test('encode string failure', () => {
-    const msg = 'Can only multibase encode buffer instances'
+    const msg = 'Unknown type, must be binary type'
     testThrow(() => multibase.encode('asdf'), msg)
   })
   test('decode int failure', () => {
     const msg = 'Can only multibase decode strings'
     testThrow(() => multibase.decode(1), msg)
   })
-  const buff = Buffer.from('test')
+  const buff = bytes.fromString('test')
   const baseTest = obj => {
     if (Array.isArray(obj)) return obj.forEach(o => baseTest(o))
     const { multibase } = multiformat()

--- a/test/test-multicodec.js
+++ b/test/test-multicodec.js
@@ -6,6 +6,16 @@ const same = assert.deepStrictEqual
 const multiformats = require('../basics')
 const test = it
 
+const testThrow = async (fn, message) => {
+  try {
+    await fn()
+  } catch (e) {
+    if (e.message !== message) throw e
+    return
+  }
+  throw new Error('Test failed to throw')
+}
+
 describe('multicodec', () => {
   const { multicodec } = multiformats
 

--- a/test/test-multicodec.js
+++ b/test/test-multicodec.js
@@ -6,35 +6,43 @@ const same = assert.deepStrictEqual
 const multiformats = require('../basics')
 const test = it
 
-const testThrow = (fn, message) => {
-  try {
-    fn()
-  } catch (e) {
-    if (e.message !== message) throw e
-    return
-  }
-  throw new Error('Test failed to throw')
-}
 describe('multicodec', () => {
   const { multicodec } = multiformats
+
   test('encode/decode raw', () => {
     const buff = multicodec.encode(Buffer.from('test'), 'raw')
     same(buff, Buffer.from('test'))
     same(multicodec.decode(buff, 'raw'), Buffer.from('test'))
   })
+
   test('encode/decode json', () => {
     const buff = multicodec.encode({ hello: 'world' }, 'json')
     same(buff, Buffer.from(JSON.stringify({ hello: 'world' })))
     same(multicodec.decode(buff, 'json'), { hello: 'world' })
   })
+
   test('raw cannot encode string', () => {
-    testThrow(() => multicodec.encode('asdf', 'raw'), 'Only buffer instances can be used w/ raw codec')
+    assert.throws(() => multicodec.encode('asdf', 'raw'), /^Error: Only buffer instances can be used w\/ raw codec$/)
   })
+
   test('get failure', () => {
-    testThrow(() => multicodec.get(true), 'Unknown key type')
-    let msg = 'Do not have multiformat entry for "8237440"'
-    testThrow(() => multicodec.get(8237440), msg)
-    msg = 'Do not have multiformat entry for "notfound"'
-    testThrow(() => multicodec.get('notfound'), msg)
+    assert.throws(() => multicodec.get(true), /^Error: Unknown key type$/)
+    let msg = /^Error: Do not have multiformat entry for "8237440"$/
+    assert.throws(() => multicodec.get(8237440), msg)
+    msg = /^Error: Do not have multiformat entry for "notfound"$/
+    assert.throws(() => multicodec.get('notfound'), msg)
+  })
+
+  test('add with function', () => {
+    let calls = 0
+    multicodec.add((...args) => {
+      calls++
+      same(args.length, 1, 'called with single arg')
+      assert(args[0] === multiformats, 'called with multiformats as argument')
+      return { code: 200, name: 'blip', encode: (a) => a[1], decode: (a) => a[2] }
+    })
+    same(calls, 1, 'called exactly once')
+    same(multicodec.encode(['one', 'two', 'three'], 'blip'), 'two', 'new codec encoder was added')
+    same(multicodec.decode(['one', 'two', 'three'], 200), 'three', 'new codec decoder was added')
   })
 })

--- a/test/test-multicodec.js
+++ b/test/test-multicodec.js
@@ -1,6 +1,6 @@
 /* globals describe, it */
 'use strict'
-const { Buffer } = require('buffer')
+const bytes = require('../bytes')
 const assert = require('assert')
 const same = assert.deepStrictEqual
 const multiformats = require('../basics')
@@ -20,19 +20,19 @@ describe('multicodec', () => {
   const { multicodec } = multiformats
 
   test('encode/decode raw', () => {
-    const buff = multicodec.encode(Buffer.from('test'), 'raw')
-    same(buff, Buffer.from('test'))
-    same(multicodec.decode(buff, 'raw'), Buffer.from('test'))
+    const buff = multicodec.encode(bytes.fromString('test'), 'raw')
+    same(buff, bytes.fromString('test'))
+    same(multicodec.decode(buff, 'raw'), bytes.fromString('test'))
   })
 
   test('encode/decode json', () => {
     const buff = multicodec.encode({ hello: 'world' }, 'json')
-    same(buff, Buffer.from(JSON.stringify({ hello: 'world' })))
+    same(buff, bytes.fromString(JSON.stringify({ hello: 'world' })))
     same(multicodec.decode(buff, 'json'), { hello: 'world' })
   })
 
-  test('raw cannot encode string', () => {
-    testThrow(() => multicodec.encode('asdf', 'raw'), 'Only Uint8Array instances can be used w/ raw codec')
+  test('raw cannot encode string', async () => {
+    await testThrow(() => multicodec.encode('asdf', 'raw'), 'Unknown type, must be binary type')
   })
 
   test('get failure', () => {
@@ -49,10 +49,12 @@ describe('multicodec', () => {
       calls++
       same(args.length, 1, 'called with single arg')
       assert(args[0] === multiformats, 'called with multiformats as argument')
-      return { code: 200, name: 'blip', encode: (a) => a[1], decode: (a) => a[2] }
+      return { code: 200, name: 'blip', encode: (a) => a[1], decode: (a) => a }
     })
     same(calls, 1, 'called exactly once')
-    same(multicodec.encode(['one', 'two', 'three'], 'blip'), 'two', 'new codec encoder was added')
-    same(multicodec.decode(['one', 'two', 'three'], 200), 'three', 'new codec decoder was added')
+    const two = bytes.fromString('two')
+    const three = bytes.fromString('three')
+    same(multicodec.encode(['one', two, three], 'blip'), two, 'new codec encoder was added')
+    same(multicodec.decode(three, 200), three, 'new codec decoder was added')
   })
 })

--- a/test/test-multihash.js
+++ b/test/test-multihash.js
@@ -31,7 +31,7 @@ const testThrowAsync = async (fn, message) => {
 }
 
 const crypto = require('crypto')
-const encode = name => data => crypto.createHash(name).update(data).digest()
+const encode = name => data => bytes.coerce(crypto.createHash(name).update(data).digest())
 
 describe('multihash', () => {
   const { multihash } = multiformat(table)
@@ -53,7 +53,7 @@ describe('multihash', () => {
       const hash = await multihash.hash(bytes.fromString('test'), 'sha2-256')
       const { digest, code } = multihash.decode(hash)
       same(code, multihash.get('sha2-256').code)
-      same(encode('sha256')(bytes.fromString('test')).compare(digest), 0)
+      same(digest, encode('sha256')(bytes.fromString('test')))
       same(await validate(hash), true)
       same(await validate(hash, bytes.fromString('test')), true)
     })
@@ -61,7 +61,7 @@ describe('multihash', () => {
       const hash = await multihash.hash(bytes.fromString('test'), 'sha2-512')
       const { digest, code } = multihash.decode(hash)
       same(code, multihash.get('sha2-512').code)
-      same(encode('sha512')(bytes.fromString('test')).compare(digest), 0)
+      same(digest, encode('sha512')(bytes.fromString('test')))
       same(await validate(hash), true)
       same(await validate(hash, bytes.fromString('test')), true)
     })

--- a/test/test-multihash.js
+++ b/test/test-multihash.js
@@ -1,5 +1,6 @@
 /* globals describe, it */
 'use strict'
+const bytes = require('../bytes')
 const assert = require('assert')
 const same = assert.deepStrictEqual
 const multiformat = require('../')
@@ -16,7 +17,7 @@ const sample = (code, size, hex) => {
     const h = i.toString(16)
     return h.length % 2 === 1 ? `0${h}` : h
   }
-  return Buffer.from(`${toHex(code)}${toHex(size)}${hex}`, 'hex')
+  return bytes.fromHex(`${toHex(code)}${toHex(size)}${hex}`)
 }
 
 const testThrowAsync = async (fn, message) => {
@@ -36,6 +37,7 @@ describe('multihash', () => {
   const { multihash } = multiformat(table)
   multihash.add(require('../hashes/sha2'))
   const { validate } = multihash
+  const empty = new Uint8Array(0)
 
   describe('encode', () => {
     test('valid', () => {
@@ -43,31 +45,31 @@ describe('multihash', () => {
         const { encoding, hex, size } = test
         const { code, name, varint } = encoding
         const buf = sample(varint || code, size, hex)
-        same(multihash.encode(Buffer.from(hex, 'hex'), code), buf)
-        same(multihash.encode(Buffer.from(hex, 'hex'), name), buf)
+        same(multihash.encode(hex ? bytes.fromHex(hex) : empty, code), buf)
+        same(multihash.encode(hex ? bytes.fromHex(hex) : empty, name), buf)
       }
     })
     test('hash sha2-256', async () => {
-      const hash = await multihash.hash(Buffer.from('test'), 'sha2-256')
+      const hash = await multihash.hash(bytes.fromString('test'), 'sha2-256')
       const { digest, code } = multihash.decode(hash)
       same(code, multihash.get('sha2-256').code)
-      same(encode('sha256')(Buffer.from('test')).compare(digest), 0)
+      same(encode('sha256')(bytes.fromString('test')).compare(digest), 0)
       same(await validate(hash), true)
-      same(await validate(hash, Buffer.from('test')), true)
+      same(await validate(hash, bytes.fromString('test')), true)
     })
     test('hash sha2-512', async () => {
-      const hash = await multihash.hash(Buffer.from('test'), 'sha2-512')
+      const hash = await multihash.hash(bytes.fromString('test'), 'sha2-512')
       const { digest, code } = multihash.decode(hash)
       same(code, multihash.get('sha2-512').code)
-      same(encode('sha512')(Buffer.from('test')).compare(digest), 0)
+      same(encode('sha512')(bytes.fromString('test')).compare(digest), 0)
       same(await validate(hash), true)
-      same(await validate(hash, Buffer.from('test')), true)
+      same(await validate(hash, bytes.fromString('test')), true)
     })
     test('no such hash', async () => {
       let msg = 'Do not have multiformat entry for "notfound"'
-      await testThrowAsync(() => multihash.hash(Buffer.from('test'), 'notfound'), msg)
+      await testThrowAsync(() => multihash.hash(bytes.fromString('test'), 'notfound'), msg)
       msg = 'Missing hash implementation for "json"'
-      await testThrowAsync(() => multihash.hash(Buffer.from('test'), 'json'), msg)
+      await testThrowAsync(() => multihash.hash(bytes.fromString('test'), 'json'), msg)
     })
   })
   describe('decode', () => {
@@ -76,31 +78,31 @@ describe('multihash', () => {
         const { encoding, hex, size } = test
         const { code, name, varint } = encoding
         const buf = sample(varint || code, size, hex)
-        const digest = Buffer.from(hex, 'hex')
+        const digest = hex ? bytes.fromHex(hex) : empty
         same(multihash.decode(buf), { code, name, digest, length: size })
       }
     })
     test('get from buffer', async () => {
-      const hash = await multihash.hash(Buffer.from('test'), 'sha2-256')
+      const hash = await multihash.hash(bytes.fromString('test'), 'sha2-256')
       const { code, name } = multihash.get(hash)
       same({ code, name }, { code: 18, name: 'sha2-256' })
     })
   })
   describe('validate', async () => {
     test('invalid hash sha2-256', async () => {
-      const hash = await multihash.hash(Buffer.from('test'), 'sha2-256')
+      const hash = await multihash.hash(bytes.fromString('test'), 'sha2-256')
       const msg = 'Buffer does not match hash'
-      await testThrowAsync(() => validate(hash, Buffer.from('tes2t')), msg)
+      await testThrowAsync(() => validate(hash, bytes.fromString('tes2t')), msg)
     })
     test('invalid fixtures', async () => {
       for (const test of invalid) {
-        const buff = Buffer.from(test.hex, 'hex')
+        const buff = bytes.fromHex(test.hex)
         await testThrowAsync(() => validate(buff), test.message)
       }
     })
   })
   test('throw on hashing non-buffer', async () => {
-    await testThrowAsync(() => multihash.hash('asdf'), 'Can only hash Buffer instances')
+    await testThrowAsync(() => multihash.hash('asdf'), 'Unknown type, must be binary type')
   })
   if (process.browser) {
     test('browser bundle', () => {


### PR DESCRIPTION
I’ve been hacking on the branch @vmx had originally created. It took more than I thought to get it all working nicely.

The tests passing in Node.js, still have some work to do in order to get the browser tests passing and to get the coverage back up to 100% now that the legacy interface has more code.