### PR TITLE
fix: hide CID#_baseCache so deepEquals() checks don't see it (again)

### DIFF
--- a/cid.js
+++ b/cid.js
@@ -25,7 +25,11 @@ module.exports = multiformats => {
   }
   class CID {
     constructor (cid, ...args) {
-      readonly(this, '_baseCache', new Map())
+      Object.defineProperty(this, '_baseCache', {
+        value: new Map(),
+        writable: false,
+        enumerable: false
+      })
       if (_CID.isCID(cid)) {
         readonly(this, 'version', cid.version)
         readonly(this, 'multihash', bytes.coerce(cid.multihash))

--- a/test/test-cid.js
+++ b/test/test-cid.js
@@ -212,8 +212,10 @@ describe('CID', () => {
     })
 
     test('works with deepEquals', () => {
-      assert.deepStrictEqual(new CID(h1), new CID(h1))
-      assert.notDeepStrictEqual(new CID(h1), new CID(h2))
+      const ch1 = new CID(h1)
+      ch1._baseCache.set('herp', 'derp')
+      assert.deepStrictEqual(ch1, new CID(h1))
+      assert.notDeepStrictEqual(ch1, new CID(h2))
     })
   })
 


### PR DESCRIPTION
This was undone in e079ffe5 but the test still passed, so make the test more robust