### PR TITLE
fix: clean backing buffer from multibase decode

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ const createMultibase = () => {
     string = string.slice(1)
     if (string.length === 0) return new Uint8Array(0)
     const { decode } = get(prefix)
-    return decode(string)
+    return Uint8Array.from(decode(string))
   }
   const encoding = string => get(string[0])
   return { add, has, get, encode, decode, encoding }

--- a/test/test-multibase.js
+++ b/test/test-multibase.js
@@ -31,6 +31,13 @@ describe('multibase', () => {
         const buffer = multibase.decode(string)
         same(buffer, bytes.fromString('test'))
       })
+      test('pristine backing buffer', () => {
+        // some deepEqual() libraries go as deep as the backing buffer, make sure it's pristine
+        const string = multibase.encode(bytes.fromString('test'), base)
+        const buffer = multibase.decode(string)
+        const expected = bytes.fromString('test')
+        same(new Uint8Array(buffer.buffer).join(','), new Uint8Array(expected.buffer).join(','))
+      })
       test('empty', () => {
         const str = multibase.encode(bytes.fromString(''), base)
         same(str, multibase.get(base).prefix)


### PR DESCRIPTION
https://github.com/ipld/js-dag-cbor/pull/1
same issue

I have mixed feelings about this, the backing buffer is there so we don't have to allocate these tiny buffers, and comparison going that deep is _probably_ wrong. In this case, whatever base-x is doing, it's allocating a _massive_ backing buffer that comes along for the ride.