### PR TITLE
feat: asCID property self reference

### DIFF
--- a/cid.js
+++ b/cid.js
@@ -29,6 +29,7 @@ export default multiformats => {
         writable: false,
         enumerable: false
       })
+      readonly(this, 'asCID', this)
       if (_CID.isCID(cid)) {
         readonly(this, 'version', cid.version)
         readonly(this, 'multihash', bytes.coerce(cid.multihash))


### PR DESCRIPTION
This came up in a conversation I had with @gozala

This feature is nice for a few reasons.

1) it’s a relatively unique property you can check that doesn’t rely on symbols.
2) this makes the toJSON() representation serializable through a Worker but, since it includes a circular reference, can still be understood as a CID instead of just a regular object.
3) this breaks CID serialization and causes an exception when you try to naively encode them as objects.

However, if we take this change it will require some updates to our codecs. In both `dag-cbor` and in `dag-json` we do an `isCircular` check before encoding an object and that runs through a relatively naive third party library that will now throw. But it’s already in my mental backlog to get rid of `is-circular` so it’s probably fine.