### PR TITLE
fix: leverage pkg.exports

### DIFF
--- a/bases/_base64.js
+++ b/bases/_base64.js
@@ -1,4 +1,4 @@
-import { coerce } from '../bytes.js'
+import { coerce } from 'multiformats/bytes.js'
 const encode = o => Buffer.from(o).toString('base64')
 const decode = s => coerce(Buffer.from(s, 'base64'))
 const __browser = false

--- a/bases/base58.js
+++ b/bases/base58.js
@@ -1,5 +1,5 @@
 import baseX from 'base-x'
-import { coerce } from '../bytes.js'
+import { coerce } from 'multiformats/bytes.js'
 import { Buffer } from 'buffer'
 
 const wrap = obj => ({

--- a/bases/base64.js
+++ b/bases/base64.js
@@ -1,4 +1,4 @@
-import * as b64 from './_base64.js'
+import * as b64 from 'multiformats/bases/_base64.js'
 
 const create = alphabet => {
   // The alphabet is only used to know:

--- a/basics.js
+++ b/basics.js
@@ -1,9 +1,9 @@
-import { create } from './index.js'
-import raw from './codecs/raw.js'
-import json from './codecs/json.js'
-import base32 from './bases/base32.js'
-import base64 from './bases/base64.js'
-import sha2 from './hashes/sha2.js'
+import { create } from 'multiformats/index.js'
+import raw from 'multiformats/codecs/raw.js'
+import json from 'multiformats/codecs/json.js'
+import base32 from 'multiformats/bases/base32.js'
+import base64 from 'multiformats/bases/base64.js'
+import sha2 from 'multiformats/hashes/sha2.js'
 
 const multiformats = create()
 multiformats.multihash.add(sha2)

--- a/cid.js
+++ b/cid.js
@@ -1,4 +1,4 @@
-import * as bytes from './bytes.js'
+import * as bytes from 'multiformats/bytes.js'
 import withIs from 'class-is'
 
 const readonly = (object, key, value) => {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import varints from 'varint'
-import createCID from './cid.js'
-import * as bytes from './bytes.js'
+import createCID from 'multiformats/cid.js'
+import * as bytes from 'multiformats/bytes.js'
 
 const cache = new Map()
 const varint = {

--- a/legacy.js
+++ b/legacy.js
@@ -1,5 +1,5 @@
 import CID from 'cids'
-import * as bytes from './bytes.js'
+import * as bytes from 'multiformats/bytes.js'
 import { Buffer } from 'buffer'
 
 const legacy = (multiformats, name) => {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,10 @@
       "import": "./index.js",
       "require": "./dist/index.cjs"
     },
+    "./index.js": {
+      "import": "./index.js",
+      "require": "./dist/index.cjs"
+    },
     "./basics.js": {
       "import": "./basics.js",
       "require": "./dist/basics.cjs"
@@ -43,9 +47,9 @@
       "require": "./dist/legacy.cjs"
     },
     "./bases/_base64.js": {
+      "browser": "./bases/_base64-browser.js",
       "import": "./bases/_base64.js",
-      "require": "./dist/bases/_base64.cjs",
-      "browser": "./bases/_base64-browser.js"
+      "require": "./dist/bases/_base64.cjs"
     },
     "./bases/base16.js": {
       "import": "./bases/base16.js",
@@ -63,21 +67,17 @@
       "import": "./bases/base64.js",
       "require": "./dist/bases/base64.cjs"
     },
-    "./hashes/sha2-browser.js": {
-      "import": "./hashes/sha2-browser.js",
-      "require": "./dist/hashes/sha2-browser.cjs"
-    },
     "./hashes/sha2.js": {
+      "browser": "./hashes/sha2-browser.js",
       "import": "./hashes/sha2.js",
-      "require": "./dist/hashes/sha2.cjs",
-      "browser": "./hashes/sha2-browser.js"
+      "require": "./dist/hashes/sha2.cjs"
     },
     "./codecs/json.js": {
-      "import": "./codecs/json.js.js",
+      "import": "./codecs/json.js",
       "require": "./dist/codecs/json.cjs"
     },
     "./codecs/raw.js": {
-      "import": "./codecs/raw.js.js",
+      "import": "./codecs/raw.js",
       "require": "./dist/codecs/raw.cjs"
     }
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "standard",
     "test:cjs": "npm run build && mocha dist/test/test-*.cjs",
     "test:node": "hundreds mocha test/test-*.js",
-    "test:browser": "polendina --cleanup test/test-*.js",
+    "test:browser": "polendina --webpack-config polendina.webpack.config.cjs --cleanup test/test-*.js",
     "test": "npm run lint && npm run test:node && npm run test:browser && npm run test:cjs",
     "coverage": "c8 --reporter=html mocha test/test-*.js && npx st -d coverage -p 8080"
   },

--- a/polendina.webpack.config.cjs
+++ b/polendina.webpack.config.cjs
@@ -1,0 +1,12 @@
+module.exports = {
+  resolve: {
+    alias: {
+      multiformats: process.cwd()
+    }
+  },
+  resolveLoader: {
+    alias: {
+      multiformats: process.cwd()
+    }
+  }
+}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,7 +3,7 @@ import path from 'path'
 
 let configs = []
 
-const _filter = p => !p.includes('/_') && !p.includes('rollup.config')
+const _filter = p => !p.includes('rollup.config')
 
 const relativeToMain = name => ({
   name: 'relative-to-main',

--- a/test/test-bytes.js
+++ b/test/test-bytes.js
@@ -1,5 +1,5 @@
 /* globals describe, it */
-import * as bytes from '../bytes.js'
+import * as bytes from 'multiformats/bytes.js'
 import { deepStrictEqual } from 'assert'
 const test = it
 const same = deepStrictEqual

--- a/test/test-cid.js
+++ b/test/test-cid.js
@@ -2,11 +2,11 @@
 import crypto from 'crypto'
 import OLDCID from 'cids'
 import assert from 'assert'
-import { toHex } from '../bytes.js'
-import multiformats from '../basics.js'
-import base58 from '../bases/base58.js'
-import base32 from '../bases/base32.js'
-import base64 from '../bases/base64.js'
+import { toHex } from 'multiformats/bytes.js'
+import multiformats from 'multiformats/basics.js'
+import base58 from 'multiformats/bases/base58.js'
+import base32 from 'multiformats/bases/base32.js'
+import base64 from 'multiformats/bases/base64.js'
 import util from 'util'
 const test = it
 const same = assert.deepStrictEqual

--- a/test/test-errors.js
+++ b/test/test-errors.js
@@ -1,6 +1,6 @@
 /* globals describe, it */
 import assert from 'assert'
-import { create } from '../index.js'
+import { create } from 'multiformats/index.js'
 const multiformat = create()
 const test = it
 

--- a/test/test-legacy.js
+++ b/test/test-legacy.js
@@ -1,8 +1,8 @@
 /* globals before, describe, it */
 import { Buffer } from 'buffer'
 import assert from 'assert'
-import multiformats from '../basics.js'
-import legacy from '../legacy.js'
+import multiformats from 'multiformats/basics.js'
+import legacy from 'multiformats/legacy.js'
 const same = assert.deepStrictEqual
 const test = it
 

--- a/test/test-multibase.js
+++ b/test/test-multibase.js
@@ -1,13 +1,13 @@
 /* globals describe, it */
-import * as bytes from '../bytes.js'
+import * as bytes from 'multiformats/bytes.js'
 import assert from 'assert'
-import { create as multiformat } from '../index.js'
-import base16 from '../bases/base16.js'
-import base32 from '../bases/base32.js'
-import base58 from '../bases/base58.js'
-import base64 from '../bases/base64.js'
-import basics from '../basics.js'
-import { __browser } from '../bases/_base64.js'
+import { create as multiformat } from 'multiformats/index.js'
+import base16 from 'multiformats/bases/base16.js'
+import base32 from 'multiformats/bases/base32.js'
+import base58 from 'multiformats/bases/base58.js'
+import base64 from 'multiformats/bases/base64.js'
+import basics from 'multiformats/basics.js'
+import { __browser } from 'multiformats/bases/_base64.js'
 const basicsMultibase = basics.multibase
 const same = assert.deepStrictEqual
 const test = it

--- a/test/test-multicodec.js
+++ b/test/test-multicodec.js
@@ -1,7 +1,7 @@
 /* globals describe, it */
-import * as bytes from '../bytes.js'
+import * as bytes from 'multiformats/bytes.js'
 import assert from 'assert'
-import multiformats from '../basics.js'
+import multiformats from 'multiformats/basics.js'
 const same = assert.deepStrictEqual
 const test = it
 

--- a/test/test-multihash.js
+++ b/test/test-multihash.js
@@ -1,12 +1,12 @@
 /* globals describe, it */
-import * as bytes from '../bytes.js'
+import * as bytes from 'multiformats/bytes.js'
 import assert from 'assert'
-import { create as multiformat } from '../index.js'
+import { create as multiformat } from 'multiformats/index.js'
 import intTable from 'multicodec/src/int-table.js'
 import valid from './fixtures/valid-multihash.js'
 import invalid from './fixtures/invalid-multihash.js'
 import crypto from 'crypto'
-import sha2 from '../hashes/sha2.js'
+import sha2 from 'multiformats/hashes/sha2.js'
 const same = assert.deepStrictEqual
 const test = it
 const encode = name => data => bytes.coerce(crypto.createHash(name).update(data).digest())


### PR DESCRIPTION
First of all: the `pkg.exports` spec defines that object key order is
being used when resolving for the targeted environment, see
https://github.com/uuidjs/uuid/pull/462#issuecomment-637571626

In order for `webpack@5` to pick up the `browser` overrides they must
come _before_ `import` and `require`, see
https://gist.github.com/sokra/e032a0f17c1721c71cfced6f14516c62 for
preliminary documentation.

To make full use of `pkg.exports` in node as well we can use package
self reference instead of local paths, see the discussion in
https://github.com/jkrems/proposal-pkg-exports/issues/47

Unfortunately the browser testing tool polendina doesn't play nice with
self reference since it only looks for bare module specifiers in
`node_modules` and `node_modules/polendina/node_modules`, see
https://github.com/rvagg/polendina/blob/master/lib/webpack.config.js#L28-L39

~~We would need a way to set up an `resolve.alias` for webpack in
polendina to make package self reference work.~~

Edit: Polendina issue fixed through https://github.com/rvagg/polendina/issues/8#issuecomment-648751938