### PR TITLE
Implement CID.asCID and depracte CID.isCID

### DIFF
--- a/cid.js
+++ b/cid.js
@@ -187,6 +187,8 @@ export default multiformats => {
       } else if (value != null && value.asCID === value) {
         const { version, code, multihash } = value
         return new CID(version, code, multihash)
+      } else if (value != null && value[cidSymbol] === true) {
+        return new CID(value)
       } else {
         return null
       }

--- a/cid.js
+++ b/cid.js
@@ -8,6 +8,18 @@ const readonly = (object, key, value) => {
   })
 }
 
+// ESM does not support importing package.json where this version info
+// should come from. To workaround it version is copied here.
+const version = '0.0.0-dev'
+// Start throwing exceptions on major version bump
+const deprecate = (range, message) => {
+  if (range.test(version)) {
+    console.warn(message)
+  } else {
+    throw new Error(message)
+  }
+}
+
 export default multiformats => {
   const { multibase, varint, multihash } = multiformats
   const parse = buff => {
@@ -181,6 +193,21 @@ export default multiformats => {
     }
 
     static isCID (value) {
+      deprecate(/^0\.0/, `CID.isCID(v) is deprecated and will be removed in the next major release.
+Following code pattern:
+
+if (CID.isCID(value)) {
+  doSomethingWithCID(value)
+} 
+
+Is replaced with:
+
+const cid = CID.asCID(value)
+if (cid) {
+  // Make sure to use cid instead of value
+  doSomethingWithCID(cid)
+}
+`)
       return !!(value && value[cidSymbol])
     }
   }

--- a/cid.js
+++ b/cid.js
@@ -157,6 +157,29 @@ export default multiformats => {
       return true
     }
 
+    /**
+     * Takes any input `value` and returns a `CID` instance if it was
+     * a `CID` otherwise returns `null`. If `value` is instanceof `CID`
+     * it will return value back. If `value` is not instance of this CID
+     * class, but is compatible CID it will return new instance of this
+     * `CID` class. Otherwise returs null.
+     *
+     * This allows two different incompatible versions of CID library to
+     * co-exist and interop as long as binary interface is compatible.
+     * @param {any} value
+     * @returns {CID|null}
+     */
+    static asCID (value) {
+      if (value instanceof CID) {
+        return value
+      } else if (value != null && value.asCID === value) {
+        const { version, code, multihash } = value
+        return new CID(version, code, multihash)
+      } else {
+        return null
+      }
+    }
+
     static isCID (value) {
       return !!(value && value[cidSymbol])
     }

--- a/cid.js
+++ b/cid.js
@@ -1,5 +1,4 @@
 import * as bytes from './bytes.js'
-import withIs from 'class-is'
 
 const readonly = (object, key, value) => {
   Object.defineProperty(object, key, {
@@ -22,6 +21,9 @@ export default multiformats => {
       ...multihash
     ])
   }
+
+  const cidSymbol = Symbol.for('@ipld/js-cid/CID')
+
   class CID {
     constructor (cid, ...args) {
       Object.defineProperty(this, '_baseCache', {
@@ -30,7 +32,7 @@ export default multiformats => {
         enumerable: false
       })
       readonly(this, 'asCID', this)
-      if (_CID.isCID(cid)) {
+      if (CID.isCID(cid)) {
         readonly(this, 'version', cid.version)
         readonly(this, 'multihash', bytes.coerce(cid.multihash))
         readonly(this, 'buffer', bytes.coerce(cid.buffer))
@@ -104,11 +106,11 @@ export default multiformats => {
         throw new Error('Cannot convert non sha2-256 multihash CID to CIDv0')
       }
 
-      return new _CID(0, this.code, this.multihash)
+      return new CID(0, this.code, this.multihash)
     }
 
     toV1 () {
-      return new _CID(1, this.code, this.multihash)
+      return new CID(1, this.code, this.multihash)
     }
 
     get toBaseEncodedString () {
@@ -146,11 +148,19 @@ export default multiformats => {
         this.version === other.version &&
         bytes.equals(this.multihash, other.multihash)
     }
+
+    get [Symbol.toStringTag] () {
+      return 'CID'
+    }
+
+    get [cidSymbol] () {
+      return true
+    }
+
+    static isCID (value) {
+      return !!(value && value[cidSymbol])
+    }
   }
 
-  const _CID = withIs(CID, {
-    className: 'CID',
-    symbolName: '@ipld/js-cid/CID'
-  })
-  return _CID
+  return CID
 }

--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "base-x": "^3.0.8",
     "buffer": "^5.6.0",
     "cids": "^0.8.3",
-    "class-is": "^1.1.0",
     "varint": "^5.0.0"
   },
   "directories": {

--- a/test/test-cid.js
+++ b/test/test-cid.js
@@ -375,6 +375,12 @@ describe('CID', () => {
 
     const cid4 = CID.asCID(cid3)
     assert.strictEqual(cid3, cid4)
+
+    const cid5 = new CID(new OLDCID(1, 'raw', Buffer.from(hash)))
+    assert.ok(cid5 instanceof CID)
+    assert.strictEqual(cid5.version, 1)
+    same(cid5.multihash, hash)
+    assert.strictEqual(cid5.code, 85)
   })
 
   test('new CID from old CID', () => {

--- a/test/test-cid.js
+++ b/test/test-cid.js
@@ -376,7 +376,7 @@ describe('CID', () => {
     const cid4 = CID.asCID(cid3)
     assert.strictEqual(cid3, cid4)
 
-    const cid5 = new CID(new OLDCID(1, 'raw', Buffer.from(hash)))
+    const cid5 = CID.asCID(new OLDCID(1, 'raw', Buffer.from(hash)))
     assert.ok(cid5 instanceof CID)
     assert.strictEqual(cid5.version, 1)
     same(cid5.multihash, hash)


### PR DESCRIPTION
This change builds upon #18 as per discussion at https://github.com/multiformats/js-cid/issues/111.

It does following:

- Introduces `.asCID` property that points to the CID instance that has it. This is a unique (enough) marker to distinguish CID values form other values.
   - Unlike `[Symbol.for('@ipld/js-cid/CID')]` marker this:
      - Marker is preserved when CID is moved across JS realms / threads (so CIDs could be identified on receiver end without sender having to do any work).
- Introduces `CID.asCID` static method as a replacement for `CID.isCID`, which improves following:
  - Two incompatible versions of CID library could co-exist and inter-op (as long as binary interface doesn't change)
  - Code (codecs) which migrate to `CID.asCID` will be able to work with `CID` instances from other threads without (receiver doing any work). Because `const cid = CID.asCID(value)` will return instance of **this** `CID` class.

--

Things I could use some help with:

- Get rid of deprecation warnings in the test output (is there way to do this with mocha ?)
- Test to verify that deprecation warning is printed. Related to above.
- Test coverage complains about line 19. I'm not sure how to exercise that line. Is the whole warn or throw worth it ? 