### PR TITLE
Array buffer view

### DIFF
--- a/bytes.js
+++ b/bytes.js
@@ -19,24 +19,17 @@ const equals = (aa, bb) => {
   return true
 }
 
-const TypedArray = Object.getPrototypeOf(Int8Array)
-const isTypedArray = obj => obj instanceof TypedArray
-
 const coerce = o => {
   if (o instanceof Uint8Array && o.constructor.name === 'Uint8Array') return o
   if (o instanceof ArrayBuffer) return new Uint8Array(o)
-  if (o instanceof DataView || isTypedArray(o)) {
+  if (ArrayBuffer.isView(o)) {
     return new Uint8Array(o.buffer, o.byteOffset, o.byteLength)
   }
   throw new Error('Unknown type, must be binary type')
 }
 
-const isBinary = o => {
-  if (o instanceof DataView) return true
-  if (o instanceof ArrayBuffer) return true
-  if (isTypedArray(o)) return true
-  return false
-}
+const isBinary = o =>
+  o instanceof ArrayBuffer || ArrayBuffer.isView(o)
 
 const fromString = str => (new TextEncoder()).encode(str)
 const toString = b => (new TextDecoder()).decode(b)

--- a/legacy.js
+++ b/legacy.js
@@ -5,10 +5,17 @@ import { Buffer } from 'buffer'
 const legacy = (multiformats, name) => {
   const toLegacy = obj => {
     if (CID.isCID(obj)) {
-      if (!obj.code) return obj
-      const { name } = multiformats.multicodec.get(obj.code)
-      return new CID(obj.version, name, Buffer.from(obj.multihash))
+      return obj
     }
+
+    const cid = multiformats.CID.asCID(obj)
+    if (cid) {
+      const { version, multihash: { buffer, byteOffset, byteLength } } = cid
+      const { name } = multiformats.multicodec.get(cid.code)
+      const multihash = Buffer.from(buffer, byteOffset, byteLength)
+      return new CID(version, name, Buffer.from(multihash))
+    }
+
     if (bytes.isBinary(obj)) return Buffer.from(obj)
     if (obj && typeof obj === 'object') {
       for (const [key, value] of Object.entries(obj)) {
@@ -18,7 +25,8 @@ const legacy = (multiformats, name) => {
     return obj
   }
   const fromLegacy = obj => {
-    if (CID.isCID(obj)) return new multiformats.CID(obj)
+    const cid = multiformats.CID.asCID(obj)
+    if (cid) return cid
     if (bytes.isBinary(obj)) return bytes.coerce(obj)
     if (obj && typeof obj === 'object') {
       for (const [key, value] of Object.entries(obj)) {

--- a/test/test-cid.js
+++ b/test/test-cid.js
@@ -2,7 +2,7 @@
 import crypto from 'crypto'
 import OLDCID from 'cids'
 import assert from 'assert'
-import { toHex } from 'multiformats/bytes.js'
+import { toHex, equals } from 'multiformats/bytes.js'
 import multiformats from 'multiformats/basics.js'
 import base58 from 'multiformats/bases/base58.js'
 import base32 from 'multiformats/bases/base32.js'
@@ -10,6 +10,8 @@ import base64 from 'multiformats/bases/base64.js'
 import util from 'util'
 const test = it
 const same = assert.deepStrictEqual
+
+// eslint-disable-next-line no-unused-vars
 
 const testThrow = async (fn, message) => {
   try {
@@ -52,7 +54,7 @@ describe('CID', () => {
   describe('v0', () => {
     test('handles B58Str multihash', () => {
       const mhStr = 'QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n'
-      const cid = new CID(mhStr)
+      const cid = CID.from(mhStr)
 
       same(cid.code, 112)
       same(cid.version, 0)
@@ -63,7 +65,7 @@ describe('CID', () => {
 
     test('create by parts', async () => {
       const hash = await multihash.hash(Buffer.from('abc'), 'sha2-256')
-      const cid = new CID(0, 112, hash)
+      const cid = CID.create(0, 112, hash)
 
       same(cid.code, 112)
       same(cid.version, 0)
@@ -74,7 +76,7 @@ describe('CID', () => {
 
     test('create from multihash', async () => {
       const hash = await multihash.hash(Buffer.from('abc'), 'sha2-256')
-      const cid = new CID(hash)
+      const cid = CID.from(hash)
 
       same(cid.code, 112)
       same(cid.version, 0)
@@ -85,42 +87,42 @@ describe('CID', () => {
 
     test('throws on invalid BS58Str multihash ', async () => {
       const msg = 'Non-base58 character'
-      testThrow(() => new CID('QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zIII'), msg)
+      testThrow(() => CID.from('QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zIII'), msg)
     })
 
     test('throws on trying to create a CIDv0 with a codec other than dag-pb', async () => {
       const hash = await multihash.hash(Buffer.from('abc'), 'sha2-256')
       const msg = 'Version 0 CID must be 112 codec (dag-cbor)'
-      testThrow(() => new CID(0, 113, hash), msg)
+      testThrow(() => CID.create(0, 113, hash), msg)
     })
 
     test('throws on trying to pass specific base encoding [deprecated]', async () => {
       const hash = await multihash.hash(Buffer.from('abc'), 'sha2-256')
       const msg = 'No longer supported, cannot specify base encoding in instantiation'
-      testThrow(() => new CID(0, 112, hash, 'base32'), msg)
+      testThrow(() => CID.create(0, 112, hash, 'base32'), msg)
     })
 
     test('throws on trying to base encode CIDv0 in other base than base58btc', () => {
       const mhStr = 'QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n'
-      const cid = new CID(mhStr)
+      const cid = CID.from(mhStr)
       const msg = 'Cannot string encode V0 in base32 encoding'
       testThrow(() => cid.toString('base32'), msg)
     })
 
-    test('.buffer', async () => {
+    test('.bytes', async () => {
       const hash = await multihash.hash(Buffer.from('abc'), 'sha2-256')
       const codec = 112
-      const cid = new CID(0, codec, hash)
-      const buffer = cid.buffer
-      assert.ok(buffer)
-      const str = toHex(buffer)
+      const cid = CID.create(0, codec, hash)
+      const bytes = cid.bytes
+      assert.ok(bytes)
+      const str = toHex(bytes)
       same(str, '1220ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad')
     })
 
     test('should construct from an old CID', () => {
       const cidStr = 'QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n'
-      const oldCid = new CID(cidStr)
-      const newCid = new CID(oldCid)
+      const oldCid = CID.from(cidStr)
+      const newCid = CID.from(oldCid)
       same(newCid.toString(), cidStr)
     })
   })
@@ -128,17 +130,17 @@ describe('CID', () => {
   describe('v1', () => {
     test('handles CID String (multibase encoded)', () => {
       const cidStr = 'zdj7Wd8AMwqnhJGQCbFxBVodGSBG84TM7Hs1rcJuQMwTyfEDS'
-      const cid = new CID(cidStr)
+      const cid = CID.from(cidStr)
       same(cid.code, 112)
       same(cid.version, 1)
       assert.ok(cid.multihash)
-      same(cid.toString(), multibase.encode(cid.buffer, 'base32'))
+      same(cid.toString(), multibase.encode(cid.bytes, 'base32'))
     })
 
     test('handles CID (no multibase)', () => {
       const cidStr = 'bafybeidskjjd4zmr7oh6ku6wp72vvbxyibcli2r6if3ocdcy7jjjusvl2u'
       const cidBuf = Buffer.from('017012207252523e6591fb8fe553d67ff55a86f84044b46a3e4176e10c58fa529a4aabd5', 'hex')
-      const cid = new CID(cidBuf)
+      const cid = CID.from(cidBuf)
       same(cid.code, 112)
       same(cid.version, 1)
       same(cid.toString(), cidStr)
@@ -146,16 +148,16 @@ describe('CID', () => {
 
     test('create by parts', async () => {
       const hash = await multihash.hash(Buffer.from('abc'), 'sha2-256')
-      const cid = new CID(1, 0x71, hash)
+      const cid = CID.create(1, 0x71, hash)
       same(cid.code, 0x71)
       same(cid.version, 1)
-      same(cid.multihash, hash)
+      assert.ok(equals(cid.multihash, hash))
     })
 
     test('can roundtrip through cid.toString()', async () => {
       const hash = await multihash.hash(Buffer.from('abc'), 'sha2-256')
-      const cid1 = new CID(1, 0x71, hash)
-      const cid2 = new CID(cid1.toString())
+      const cid1 = CID.create(1, 0x71, hash)
+      const cid2 = CID.from(cid1.toString())
 
       same(cid1.code, cid2.code)
       same(cid1.version, cid2.version)
@@ -166,8 +168,8 @@ describe('CID', () => {
     test('handles multibyte varint encoded codec codes', () => {
       const ethBlockHash = Buffer.from('8a8e84c797605fbe75d5b5af107d4220a2db0ad35fd66d9be3d38d87c472b26d', 'hex')
       const mh = multihash.encode(ethBlockHash, 'keccak-256')
-      const cid1 = new CID(1, 'eth-block', mh)
-      const cid2 = new CID(cid1.toBaseEncodedString())
+      const cid1 = CID.create(1, 'eth-block', mh)
+      const cid2 = CID.from(cid1.toBaseEncodedString())
 
       same(cid1.codec, 'eth-block')
       same(cid1.version, 1)
@@ -179,20 +181,20 @@ describe('CID', () => {
     })
     */
 
-    test('.buffer', async () => {
+    test('.bytes', async () => {
       const hash = await multihash.hash(Buffer.from('abc'), 'sha2-256')
       const code = 0x71
-      const cid = new CID(1, code, hash)
-      const buffer = cid.buffer
-      assert.ok(buffer)
-      const str = toHex(buffer)
+      const cid = CID.create(1, code, hash)
+      const bytes = cid.bytes
+      assert.ok(bytes)
+      const str = toHex(bytes)
       same(str, '01711220ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad')
     })
 
     test('should construct from an old CID without a multibaseName', () => {
       const cidStr = 'bafybeidskjjd4zmr7oh6ku6wp72vvbxyibcli2r6if3ocdcy7jjjusvl2u'
-      const oldCid = new CID(cidStr)
-      const newCid = new CID(oldCid)
+      const oldCid = CID.from(cidStr)
+      const newCid = CID.from(oldCid)
       same(newCid.toString(), cidStr)
     })
   })
@@ -202,71 +204,71 @@ describe('CID', () => {
     const h2 = 'QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1o'
 
     test('.equals v0 to v0', () => {
-      same(new CID(h1).equals(new CID(h1)), true)
-      same(new CID(h1).equals(new CID(h2)), false)
+      same(CID.from(h1).equals(CID.from(h1)), true)
+      same(CID.from(h1).equals(CID.from(h2)), false)
     })
 
     test('.equals v0 to v1 and vice versa', () => {
       const cidV1Str = 'zdj7Wd8AMwqnhJGQCbFxBVodGSBG84TM7Hs1rcJuQMwTyfEDS'
-      const cidV1 = new CID(cidV1Str)
+      const cidV1 = CID.from(cidV1Str)
       const cidV0 = cidV1.toV0()
 
       same(cidV0.equals(cidV1), false)
       same(cidV1.equals(cidV0), false)
+
       same(cidV1.multihash, cidV0.multihash)
     })
 
     test('.isCid', () => {
-      assert.ok(CID.isCID(new CID(h1)))
+      assert.ok(CID.isCID(CID.from(h1)))
 
       assert.ok(!CID.isCID(false))
 
       assert.ok(!CID.isCID(Buffer.from('hello world')))
 
-      assert.ok(CID.isCID(new CID(h1).toV0()))
+      assert.ok(CID.isCID(CID.from(h1).toV0()))
 
-      assert.ok(CID.isCID(new CID(h1).toV1()))
+      assert.ok(CID.isCID(CID.from(h1).toV1()))
     })
 
     test('works with deepEquals', () => {
-      const ch1 = new CID(h1)
+      const ch1 = CID.from(h1)
       ch1._baseCache.set('herp', 'derp')
-      assert.deepStrictEqual(ch1, new CID(h1))
-      assert.notDeepStrictEqual(ch1, new CID(h2))
+      assert.deepStrictEqual(ch1, CID.from(h1))
+      assert.notDeepStrictEqual(ch1, CID.from(h2))
     })
   })
 
   describe('throws on invalid inputs', () => {
-    const invalid = [
+    const from = [
       'hello world',
       'QmaozNR7DZHQK1ZcU9p7QdrshMvXqWK6gpu5rmrkPdT3L',
       Buffer.from('hello world'),
-      Buffer.from('QmaozNR7DZHQK1ZcU9p7QdrshMvXqWK6gpu5rmrkPdT')
+      Buffer.from('QmaozNR7DZHQK1ZcU9p7QdrshMvXqWK6gpu5rmrkPdT'),
+      {}
     ]
 
-    let mapper = i => {
-      const name = `new CID(${Buffer.isBuffer(i) ? 'buffer' : 'string'}<${i.toString()}>)`
-      test(name, () => testThrowAny(() => new CID(i)))
+    for (const i of from) {
+      const name = `CID.from(${Buffer.isBuffer(i) ? 'buffer' : 'string'}<${i.toString()}>)`
+      test(name, () => testThrowAny(() => CID.from(i)))
     }
-    invalid.forEach(mapper)
 
-    mapper = i => {
-      const name = `new CID(0, 112, ${Buffer.isBuffer(i) ? 'buffer' : 'string'}<${i.toString()}>)`
-      test(name, () => testThrowAny(() => new CID(0, 112, i)))
-    }
-    invalid.forEach(mapper)
+    const create = [
+      ...from.map(i => [0, 112, i]),
+      ...from.map(i => [1, 112, i]),
+      [18, 112, 'QmaozNR7DZHQK1ZcU9p7QdrshMvXqWK6gpu5rmrkPdT3L']
+    ]
 
-    mapper = i => {
-      const name = `new CID(1, 112, ${Buffer.isBuffer(i) ? 'buffer' : 'string'}<${i.toString()}>)`
-      test(name, () => testThrowAny(() => new CID(1, 112, i)))
+    for (const [version, code, hash] of create) {
+      const name = `CID.create(${version}, ${code}, ${Buffer.isBuffer(hash) ? 'buffer' : 'string'}<${hash.toString()}>)`
+      test(name, () => testThrowAny(() => CID.create(version, code, hash)))
     }
-    invalid.forEach(mapper)
   })
 
   describe('idempotence', () => {
     const h1 = 'QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n'
-    const cid1 = new CID(h1)
-    const cid2 = new CID(cid1)
+    const cid1 = CID.from(h1)
+    const cid2 = CID.from(cid1)
 
     test('constructor accept constructed instance', () => {
       same(cid1.equals(cid2), true)
@@ -277,25 +279,25 @@ describe('CID', () => {
   describe('conversion v0 <-> v1', () => {
     test('should convert v0 to v1', async () => {
       const hash = await multihash.hash(Buffer.from(`TEST${Date.now()}`), 'sha2-256')
-      const cid = (new CID(0, 112, hash)).toV1()
+      const cid = (CID.create(0, 112, hash)).toV1()
       same(cid.version, 1)
     })
 
     test('should convert v1 to v0', async () => {
       const hash = await multihash.hash(Buffer.from(`TEST${Date.now()}`), 'sha2-256')
-      const cid = (new CID(1, 112, hash)).toV0()
+      const cid = (CID.create(1, 112, hash)).toV0()
       same(cid.version, 0)
     })
 
     test('should not convert v1 to v0 if not dag-pb codec', async () => {
       const hash = await multihash.hash(Buffer.from(`TEST${Date.now()}`), 'sha2-256')
-      const cid = new CID(1, 0x71, hash)
+      const cid = CID.create(1, 0x71, hash)
       await testThrow(() => cid.toV0(), 'Cannot convert a non dag-pb CID to CIDv0')
     })
 
     test('should not convert v1 to v0 if not sha2-256 multihash', async () => {
       const hash = await multihash.hash(Buffer.from(`TEST${Date.now()}`), 'sha2-512')
-      const cid = new CID(1, 112, hash)
+      const cid = CID.create(1, 112, hash)
       await testThrow(() => cid.toV0(), 'Cannot convert non sha2-256 multihash CID to CIDv0')
     })
   })
@@ -303,13 +305,13 @@ describe('CID', () => {
   describe('caching', () => {
     test('should cache CID as buffer', async () => {
       const hash = await multihash.hash(Buffer.from(`TEST${Date.now()}`), 'sha2-256')
-      const cid = new CID(1, 112, hash)
-      assert.ok(cid.buffer)
-      same(cid.buffer, cid.buffer)
+      const cid = CID.create(1, 112, hash)
+      assert.ok(cid.bytes)
+      same(cid.bytes, cid.bytes)
     })
     test('should cache string representation when it matches the multibaseName it was constructed with', async () => {
       const hash = await multihash.hash(Buffer.from('abc'), 'sha2-256')
-      const cid = new CID(1, 112, hash)
+      const cid = CID.create(1, 112, hash)
       same(cid._baseCache.size, 0)
 
       same(cid.toString('base64'), 'mAXASILp4Fr+PAc/qQUFA3l2uIiOwA2Gjlhd6nLQQ/2HyABWt')
@@ -325,21 +327,24 @@ describe('CID', () => {
     })
     test('should cache string representation when constructed with one', () => {
       const base32String = 'bafybeif2pall7dybz7vecqka3zo24irdwabwdi4wc55jznaq75q7eaavvu'
-      const cid = new CID(base32String)
+      const cid = CID.from(base32String)
       same(cid._baseCache.get('base32'), base32String)
     })
   })
 
   test('toJSON()', async () => {
     const hash = await multihash.hash(Buffer.from('abc'), 'sha2-256')
-    const cid = new CID(1, 112, hash)
-    same(cid.toJSON(), { code: 112, version: 1, hash })
+    const cid = CID.create(1, 112, hash)
+    const json = cid.toJSON()
+
+    same({ ...json, hash: null }, { code: 112, version: 1, hash: null })
+    assert.ok(equals(json.hash, hash))
   })
 
   test('isCID', async () => {
     const hash = await multihash.hash(Buffer.from('abc'), 'sha2-256')
-    const cid = new CID(1, 112, hash)
-    assert.ok(OLDCID.isCID(cid))
+    const cid = CID.create(1, 112, hash)
+    assert.strictEqual(OLDCID.isCID(cid), false)
   })
 
   test('asCID', async () => {
@@ -370,7 +375,7 @@ describe('CID', () => {
     assert.ok(cid1 instanceof CID)
     assert.strictEqual(cid1.code, code)
     assert.strictEqual(cid1.version, version)
-    assert.strictEqual(cid1.multihash, _multihash)
+    assert.ok(equals(cid1.multihash, _multihash))
 
     const cid2 = CID.asCID({ version, code, _multihash })
     assert.strictEqual(cid2, null)
@@ -381,7 +386,7 @@ describe('CID', () => {
     assert.ok(cid3 instanceof CID)
     assert.strictEqual(cid3.code, code)
     assert.strictEqual(cid3.version, version)
-    assert.strictEqual(cid3.multihash, _multihash)
+    assert.ok(equals(cid3.multihash, _multihash))
 
     const cid4 = CID.asCID(cid3)
     assert.strictEqual(cid3, cid4)
@@ -389,22 +394,23 @@ describe('CID', () => {
     const cid5 = CID.asCID(new OLDCID(1, 'raw', Buffer.from(hash)))
     assert.ok(cid5 instanceof CID)
     assert.strictEqual(cid5.version, 1)
-    same(cid5.multihash, hash)
+    assert.ok(equals(cid5.multihash, hash))
     assert.strictEqual(cid5.code, 85)
   })
 
   test('new CID from old CID', async () => {
     const hash = await multihash.hash(Buffer.from('abc'), 'sha2-256')
-    const cid = new CID(new OLDCID(1, 'raw', Buffer.from(hash)))
+    const cid = CID.from(new OLDCID(1, 'raw', Buffer.from(hash)))
     same(cid.version, 1)
-    same(cid.multihash, hash)
+
+    assert.ok(equals(cid.multihash, hash))
     same(cid.code, 85)
   })
 
   if (!process.browser) {
     test('util.inspect', async () => {
       const hash = await multihash.hash(Buffer.from('abc'), 'sha2-256')
-      const cid = new CID(1, 112, hash)
+      const cid = CID.create(1, 112, hash)
       same(util.inspect(cid), 'CID(bafybeif2pall7dybz7vecqka3zo24irdwabwdi4wc55jznaq75q7eaavvu)')
     })
   }
@@ -412,29 +418,29 @@ describe('CID', () => {
   describe('deprecations', async () => {
     test('codec', async () => {
       const hash = await multihash.hash(Buffer.from('abc'), 'sha2-256')
-      const cid = new CID(1, 112, hash)
+      const cid = CID.create(1, 112, hash)
       await testThrow(() => cid.codec, '"codec" property is deprecated, use integer "code" property instead')
-      await testThrow(() => new CID(1, 'dag-pb', hash), 'String codecs are no longer supported')
+      await testThrow(() => CID.create(1, 'dag-pb', hash), 'String codecs are no longer supported')
     })
     test('multibaseName', async () => {
       const hash = await multihash.hash(Buffer.from('abc'), 'sha2-256')
-      const cid = new CID(1, 112, hash)
+      const cid = CID.create(1, 112, hash)
       await testThrow(() => cid.multibaseName, '"multibaseName" property is deprecated')
     })
     test('prefix', async () => {
       const hash = await multihash.hash(Buffer.from('abc'), 'sha2-256')
-      const cid = new CID(1, 112, hash)
+      const cid = CID.create(1, 112, hash)
       await testThrow(() => cid.prefix, '"prefix" property is deprecated')
     })
     test('toBaseEncodedString()', async () => {
       const hash = await multihash.hash(Buffer.from('abc'), 'sha2-256')
-      const cid = new CID(1, 112, hash)
+      const cid = CID.create(1, 112, hash)
       await testThrow(() => cid.toBaseEncodedString(), 'Deprecated, use .toString()')
     })
   })
 
   test('invalid CID version', async () => {
     const encoded = varint.encode(2)
-    await testThrow(() => new CID(encoded), 'Invalid CID version 2')
+    await testThrow(() => CID.from(encoded), 'Invalid CID version 2')
   })
 })

--- a/test/test-legacy.js
+++ b/test/test-legacy.js
@@ -38,7 +38,7 @@ describe('multicodec', () => {
       decode: buff => {
         const obj = json.util.deserialize(buff)
         obj.l = link
-        if (obj.o.link) obj.link = new multiformats.CID(link)
+        if (obj.o.link) obj.link = multiformats.CID.from(link)
         return obj
       }
     })


### PR DESCRIPTION
This pull request changes CID representation to a glorified ArrayBuffer view (as per https://github.com/multiformats/js-cid/issues/111#issuecomment-656281072 and discussions in other higher bandwidth channels). Primary goal here is to illustrate and discuss the concept, which is why it end up mixing bunch of things (we can spin smaller pull request from this as necessary).

### Overview

- Mail goal is to make CID just be a glorified view over the binary CID (just like all the other typed arrays). That is to say it complies with `ArrayBufferView` interface as defined below:
   ```js
    interface ArrayBufferView {
     byteOffset: number,
     byteLength: number,
     buffer: ArrayBuffer
   }
  ```

  - This also implies that `CID` can represent view into the larger buffer. This provides nice benefits when using binary protocol to move data across threads or processes.
- **This is not strictly necessary, but** it simplifies `CID` constructor so it's in the spirit of other `ArrayBufferView`s.
   - It introduces `CID.from(v)` (again as other views) to make `CID` from string and all other supported inputs.
   - It introduces `CID.create(version, code, bytes)` for creating `CID` out of given parameters.
   - It makes constructor of following type
       ```js
       interface CID {
          constructor(buffer:ArrayBuffer, byteOffset=0, byteLength:buffer.byteLength)
          constructor(ArrayBufferView)
       }
       ```
- Renames previously existing `buffer` field to `bytes`, because `buffer` needs to be an `ArrayBuffer`. It is also aligned with recent change in old CIDs as per https://github.com/multiformats/js-cid/pull/117