### PR TITLE
fix: run ts-use check properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
   "typesVersions": {
     "*": {
       "*": [
-        "dist/types/*"
+        "types/*"
       ]
     }
   }

--- a/test/ts-use/package.json
+++ b/test/ts-use/package.json
@@ -2,9 +2,9 @@
   "name": "ts-use",
   "private": true,
   "dependencies": {
-    "multiformats": "file:../.."
+    "multiformats": "file:../../dist/"
   },
   "scripts": {
-    "test": "npm install && npx tsc --noEmit"
+    "test": "npm install && npx -p typescript tsc --noEmit"
   }
 }


### PR DESCRIPTION
We publish from the `dist` directory, to package.json needs to have a `"typesVersions"` relative to that and currently it points into `dist/` so the types don't get picked up by consuming packages.

This fixes that problem and the local checks run so it seems that this is fine for local dev 🤞.

ts-use was also calling to `npx tsc` which is the wrong package (needs to be `-p typescript`).