### PR TITLE
fix: specify src path to index.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "multiformats",
   "version": "0.0.0-dev",
   "description": "Interface for multihash, multicodec, multibase and CID",
-  "main": "index.js",
+  "main": "./src/index.js",
   "type": "module",
   "scripts": {
     "build": "npm run build:js && npm run build:types",


### PR DESCRIPTION
Signed-off-by: Carson Farmer <carson.farmer@gmail.com>

Some parsers don't understand exports, and fallback to main... right now, this causes issues, as the "main" key points to a non-existent file. For example, in React Native, the following error occurs when importing this module:

```
Error: While trying to resolve module `multiformats` from file `.../MyApp/node_modules/some/dep/package/index.js`, the package `.../MyApp/node_modules/multiformats/package.json` was successfully found. However, this package itself specifies a `main` module field that could not be resolved (`.../MyApp/node_modules/multiformats/index`. Indeed, none of these files exist:
```

The "fix" is to manually go in and specify:

```
...
"main": "./cjs/src/index.js",
...
```