### PR TITLE
add CID.encodedLength() & remove leading uint32 CID length from encoded aes form

### DIFF
--- a/test/fixtures/invalid-multihash.js
+++ b/test/fixtures/invalid-multihash.js
@@ -28,4 +28,9 @@ export default [{
   size: 32,
   hex: '2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7',
   message: 'Incorrect length'
+}, {
+  code: 0x12,
+  size: 32,
+  hex: '1220ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad0000',
+  message: 'Incorrect length'
 }]


### PR DESCRIPTION
There's two commits in here, the first one could go against `master` but it's used for the second one which is intended for `crypto`, #349. If this is an acceptable approach I'll write up some additional tests to exercise `encodedLength()` a bit more (CIDv0 and bad bytes - and these would be good to do with the aes tests too).

Ref: https://github.com/ipld/specs/pull/349#issuecomment-759649987