### PR TITLE
fix: make hashing work in web workers

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "check": "tsc --noEmit --noErrorTruncation",
     "test:cjs": "npm run build:js && mocha dist/cjs/node-test/test-*.js && npm run test:cjs:browser",
     "test:node": "hundreds mocha test/test-*.js",
-    "test:cjs:browser": "polendina --cleanup dist/cjs/browser-test/test-*.js",
+    "test:cjs:browser": "polendina --page --worker --serviceworker --cleanup dist/cjs/browser-test/test-*.js",
     "test:ts": "npm run build:types && npm run test --prefix test/ts-use",
     "test": "npm run lint && npm run test:node && npm run test:cjs && npm run test:ts",
     "test:node-v12": "mocha test/test-*.js && npm run test:cjs",

--- a/src/hashes/sha2-browser.js
+++ b/src/hashes/sha2-browser.js
@@ -1,3 +1,5 @@
+/* global crypto */
+
 import { from } from './hasher.js'
 
 /**
@@ -7,7 +9,7 @@ const sha = name =>
   /**
    * @param {Uint8Array} data
    */
-  async data => new Uint8Array(await window.crypto.subtle.digest(name, data))
+  async data => new Uint8Array(await crypto.subtle.digest(name, data))
 
 export const sha256 = from({
   name: 'sha2-256',


### PR DESCRIPTION
`window` isn't available in web workers, hence use `self` instead.

@Gozala you know a thing or to about web workers. Is that the correct fix that also works outside of web workers?