### PR TITLE
fix: fix legacy resolving

### DIFF
--- a/src/legacy.js
+++ b/src/legacy.js
@@ -106,7 +106,7 @@ const legacy = (codec, { hashes }) => {
         return { value, remainderPath: entries.join('/') }
       }
     }
-    return { value }
+    return { value, remainderPath: '' }
   }
 
   /**

--- a/test/test-legacy.js
+++ b/test/test-legacy.js
@@ -84,9 +84,9 @@ describe('multicodec', () => {
       }
     })
     let value = { hello: 'world' }
-    same(custom.resolver.resolve(fixture, 'o/one/two'), { value })
+    same(custom.resolver.resolve(fixture, 'o/one/two'), { value, remainderPath: '' })
     value = 'world'
-    same(custom.resolver.resolve(fixture, 'o/one/two/hello'), { value })
+    same(custom.resolver.resolve(fixture, 'o/one/two/hello'), { value, remainderPath: '' })
     value = link
     same(custom.resolver.resolve(fixture, 'l/outside'), { value, remainderPath: 'outside' })
     await testThrow(() => custom.resolver.resolve(fixture, 'o/two'), 'Not found')


### PR DESCRIPTION
The resolving always returns a `remainderPath`, even if it's an empty string.