### PR TITLE
Fix minor README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # multiformats
 
-This library defines common interfaces and low level building blocks for varios inter-related multiformat technologies (multicodec, multihash, multibase,
+This library defines common interfaces and low level building blocks for various interrelated multiformat technologies (multicodec, multihash, multibase,
 and CID). They can be used to implement custom custom base
 encoders / decoders / codecs, codec encoders /decoders and multihash hashers that comply to the interface that layers above assume.
 


### PR DESCRIPTION
Hey 👋 Super small thing, but I noticed a small typo in the first sentence of the README ("varios"). Here's a fix!