### PR TITLE
fix: typo in error name

### DIFF
--- a/src/cid.js
+++ b/src/cid.js
@@ -396,7 +396,7 @@ const parseCIDtoBytes = (source, base) => {
     }
     default: {
       if (base == null) {
-        throw Error('To parse non base32 or base56btc encoded CID multibase decoder must be provided')
+        throw Error('To parse non base32 or base58btc encoded CID multibase decoder must be provided')
       }
       return [source[0], base.decode(source)]
     }

--- a/test/test-cid.js
+++ b/test/test-cid.js
@@ -506,7 +506,7 @@ describe('CID', () => {
     test('fails to parse base64 encoded CIDv1', async () => {
       const hash = await sha256.digest(Buffer.from('abc'))
       const cid = CID.create(1, 112, hash)
-      const msg = 'To parse non base32 or base56btc encoded CID multibase decoder must be provided'
+      const msg = 'To parse non base32 or base58btc encoded CID multibase decoder must be provided'
 
       await testThrow(() => CID.parse(cid.toString(base64)), msg)
     })


### PR DESCRIPTION
`base56btc` should be `base58btc`