### PR TITLE
feat: support v0 identity cids

### DIFF
--- a/src/cid.js
+++ b/src/cid.js
@@ -331,7 +331,8 @@ export class CID {
 
     let version = next()
     let codec = DAG_PB_CODE
-    if (version === 18) { // CIDv0
+
+    if (version === 18 || version === 0) { // CIDv0 sha2-256 or identity
       version = 0
       offset = 0
     } else if (version === 1) {
@@ -382,7 +383,8 @@ export class CID {
 const parseCIDtoBytes = (source, base) => {
   switch (source[0]) {
     // CIDv0 is parsed differently
-    case 'Q': {
+    case 'Q': // sha2-256
+    case '1': { // identity
       const decoder = base || base58btc
       return [base58btc.prefix, decoder.decode(`${base58btc.prefix}${source}`)]
     }

--- a/test/test-cid.js
+++ b/test/test-cid.js
@@ -518,6 +518,16 @@ describe('CID', () => {
       const parsed = CID.parse(cid.toString(base64), base64)
       digestsame(cid, parsed)
     })
+
+    test('parses base58btc implicit encoded identity CIDv0', async () => {
+      const prefix = '1'
+      const hash = '6Uiu2HAmGKisxKeBRLyGyKD8MuQFAiUUnPABGhvWna28CSd7WzFE'
+      const cid = CID.parse(`${prefix}${hash}`)
+
+      assert.strictEqual(cid.multihash.code, 0x00)
+
+      same(cid.multihash.digest, base58btc.decode(`z${hash}`).slice(1))
+    })
   })
 
   test('inspect bytes', () => {


### PR DESCRIPTION
When dealing with PeerIDs we commonly encode them as v0 CIDs using base58btc encoded multihashes with the identity hash.

The change here is to support `1` prefixed CIDv0 as a special case (e.g. the identity hash) similar to how we support `Q` prefixed CIDv0 as a special case (e.g. sha2-256).

This lets us parse and validate peer IDs out of multiaddrs, among other things.

Fixes #90