### PR TITLE
feat: add name and code fields to MultihashHasher interface

### DIFF
--- a/src/bases/interface.ts
+++ b/src/bases/interface.ts
@@ -1,5 +1,5 @@
 // Base encoders / decoders just base encode / decode between binary and
-// textual represenatinon. They are unaware of multibase.
+// textual representation. They are unaware of multibase.
 
 /**
  * Base encoder just encodes bytes into base encoded string.
@@ -18,9 +18,9 @@ export interface BaseEncoder {
  */
 export interface BaseDecoder {
   /**
-   * Decodes **plain** (and not a multibase) string. Unilke
-   * decode 
-   * @param text 
+   * Decodes **plain** (and not a multibase) string. Unlike
+   * decode
+   * @param text
    */
   baseDecode(text: string): Uint8Array
 }
@@ -34,7 +34,7 @@ export interface BaseCodec {
 }
 
 /**
- * Multibase represets base encoded strings with a prefix first character
+ * Multibase represents base encoded strings with a prefix first character
  * describing it's encoding.
  */
 export type Multibase<Prefix extends string> =
@@ -70,8 +70,8 @@ export interface MultibaseEncoder<Prefix extends string> {
 export interface MultibaseDecoder<Prefix extends string> {
   /**
    * Decodes **multibase** string (which must have a multibase prefix added).
-   * If prefix does not match 
-   * @param multibase 
+   * If prefix does not match
+   * @param multibase
    */
   decode(multibase: Multibase<Prefix>): Uint8Array
 }

--- a/src/cid.js
+++ b/src/cid.js
@@ -285,7 +285,7 @@ export class CID {
   }
 
   /**
-   * Decoded a CID from its binary representation at the begining of a byte
+   * Decoded a CID from its binary representation at the beginning of a byte
    * array.
    *
    * Returns an array with the first element containing the CID and the second

--- a/src/hashes/interface.ts
+++ b/src/hashes/interface.ts
@@ -2,7 +2,7 @@
 
 /**
  * Represents a multihash digest which carries information about the
- * hashing alogrithm and an actual hash digest.
+ * hashing algorithm and an actual hash digest.
  */
 // Note: In the current version there is no first class multihash
 // representation (plain Uint8Array is used instead) instead there seems to be
@@ -31,7 +31,6 @@ export interface MultihashDigest {
   bytes: Uint8Array
 }
 
-
 /**
  * Hasher represents a hashing algorithm implementation that produces as
  * `MultihashDigest`.
@@ -47,5 +46,9 @@ export interface MultihashHasher {
    * Name of the multihash
    */
    name: string
-}
 
+  /**
+   * Code of the multihash
+   */
+  code: number
+}

--- a/src/hashes/interface.ts
+++ b/src/hashes/interface.ts
@@ -42,5 +42,10 @@ export interface MultihashHasher {
    * @param {Uint8Array} input
    */
   digest(input: Uint8Array): Promise<MultihashDigest>
+
+  /**
+   * Name of the multihash
+   */
+   name: string
 }
 


### PR DESCRIPTION
This appears to have been missed off, unless it's been done on purpose?

Makes `MultihashHasher` consistent with `MultibaseEncoder`, `BlockEncoder`, etc.

Also fixes a small typo.