### PR TITLE
feat: add missing upper case versions of base16 and base32 multibase codecs

### DIFF
--- a/src/bases/base16.js
+++ b/src/bases/base16.js
@@ -10,3 +10,11 @@ export const base16 = withAlphabet({
   encode: toHex,
   decode: fromHex
 })
+
+export const base16upper = withAlphabet({
+  prefix: 'F',
+  name: 'base16upper',
+  alphabet: '0123456789ABCDEF',
+  encode: toHex,
+  decode: fromHex
+})

--- a/src/bases/base32.js
+++ b/src/bases/base32.js
@@ -75,10 +75,26 @@ export const base32 = withAlphabet({
   decode
 })
 
+export const base32upper = withAlphabet({
+  prefix: 'B',
+  name: 'base32upper',
+  alphabet: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567',
+  encode,
+  decode
+})
+
 export const base32pad = withAlphabet({
   prefix: 'c',
   name: 'base32pad',
   alphabet: 'abcdefghijklmnopqrstuvwxyz234567=',
+  encode,
+  decode
+})
+
+export const base32padupper = withAlphabet({
+  prefix: 'C',
+  name: 'base32padupper',
+  alphabet: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567=',
   encode,
   decode
 })
@@ -91,10 +107,26 @@ export const base32hex = withAlphabet({
   decode
 })
 
+export const base32hexupper = withAlphabet({
+  prefix: 'V',
+  name: 'base32hexupper',
+  alphabet: '0123456789ABCDEFGHIJKLMNOPQRSTUV',
+  encode,
+  decode
+})
+
 export const base32hexpad = withAlphabet({
   prefix: 't',
   name: 'base32hexpad',
   alphabet: '0123456789abcdefghijklmnopqrstuv=',
+  encode,
+  decode
+})
+
+export const base32hexpadupper = withAlphabet({
+  prefix: 'T',
+  name: 'base32hexpadupper',
+  alphabet: '0123456789ABCDEFGHIJKLMNOPQRSTUV=',
   encode,
   decode
 })


### PR DESCRIPTION
These were not present, I'm not sure why not but we use them in a few places so add them so we don't need to change the case of strings before decoding them.