### PR TITLE
feat: add base36 encoding/decoding

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,9 @@
     "./bases/base32": {
       "import": "./src/bases/base32.js"
     },
+    "./bases/base36": {
+      "import": "./src/bases/base36.js"
+    },
     "./bases/base58": {
       "import": "./src/bases/base58.js"
     },

--- a/src/bases/base.js
+++ b/src/bases/base.js
@@ -1,3 +1,6 @@
+import baseX from '../../vendor/base-x.js'
+import { coerce } from '../bytes.js'
+
 /**
  * @typedef {import('./interface').BaseEncoder} BaseEncoder
  * @typedef {import('./interface').BaseDecoder} BaseDecoder
@@ -275,3 +278,17 @@ export const withSettings = ({ name, prefix, settings, encode, decode }) =>
  */
 export const from = ({ name, prefix, encode, decode }) =>
   new Codec(name, prefix, encode, decode)
+
+/**
+ * @param {string} alphabet
+ */
+export const implement = (alphabet) => {
+  const { encode, decode } = baseX(alphabet)
+  return {
+    encode,
+    /**
+     * @param {string} text
+     */
+    decode: text => coerce(decode(text))
+  }
+}

--- a/src/bases/base32.js
+++ b/src/bases/base32.js
@@ -2,7 +2,7 @@ import { withAlphabet } from './base.js'
 
 /**
  * @param {string} input
- * @param {input} alphabet
+ * @param {string} alphabet
  */
 function decode (input, alphabet) {
   input = input.replace(/=/g, '')

--- a/src/bases/base36.js
+++ b/src/bases/base36.js
@@ -1,0 +1,13 @@
+import { from, implement } from './base.js'
+
+export const base36 = from({
+  prefix: 'k',
+  name: 'base36',
+  ...implement('0123456789abcdefghijklmnopqrstuvwxyz')
+})
+
+export const base36upper = from({
+  prefix: 'K',
+  name: 'base36upper',
+  ...implement('0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ')
+})

--- a/src/bases/base58.js
+++ b/src/bases/base58.js
@@ -1,20 +1,4 @@
-import baseX from '../../vendor/base-x.js'
-import { coerce } from '../bytes.js'
-import { from } from './base.js'
-
-/**
- * @param {string} alphabet
- */
-const implement = (alphabet) => {
-  const { encode, decode } = baseX(alphabet)
-  return {
-    encode,
-    /**
-     * @param {string} text
-     */
-    decode: text => coerce(decode(text))
-  }
-}
+import { from, implement } from './base.js'
 
 export const base58btc = from({
   name: 'base58btc',

--- a/test/test-multibase.js
+++ b/test/test-multibase.js
@@ -3,6 +3,7 @@ import * as bytes from '../src/bytes.js'
 import assert from 'assert'
 import * as b16 from 'multiformats/bases/base16'
 import * as b32 from 'multiformats/bases/base32'
+import * as b36 from 'multiformats/bases/base36'
 import * as b58 from 'multiformats/bases/base58'
 import * as b64 from 'multiformats/bases/base64'
 
@@ -87,6 +88,9 @@ describe('multibase', () => {
   describe('base32', () => {
     baseTest(b32)
   })
+  describe('base36', () => {
+    baseTest(b36)
+  })
   describe('base58', () => {
     baseTest(b58)
   })
@@ -116,7 +120,7 @@ describe('multibase', () => {
     const baseExt = base.or(base64)
     same(baseExt.decode(b64), bytes.fromString('test'))
 
-    // original composition stayes intact
+    // original composition stays intact
     testThrow(() => base.decode(b64), msg)
   })
 })


### PR DESCRIPTION
Adds base36 encoding/decoding as it's in the multibase table and is used by ipns.

Reuses the base-x alphabet implementation as that's what js-multibase used to do.

Moves the `implement` function from base58.js into base.js so it can be reused by base36.