### PR TITLE
feat: add missing encodings and spec tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,18 @@
     "./block": {
       "import": "./src/block.js"
     },
+    "./bases/identity": {
+      "import": "./src/bases/identity.js"
+    },
+    "./bases/base2": {
+      "import": "./src/bases/base2.js"
+    },
+    "./bases/base8": {
+      "import": "./src/bases/base8.js"
+    },
+    "./bases/base10": {
+      "import": "./src/bases/base10.js"
+    },
     "./bases/base16": {
       "import": "./src/bases/base16.js"
     },

--- a/src/bases/base.js
+++ b/src/bases/base.js
@@ -1,4 +1,4 @@
-import baseX from '../../vendor/base-x.js'
+import basex from '../../vendor/base-x.js'
 import { coerce } from '../bytes.js'
 
 /**
@@ -234,17 +234,25 @@ export const from = ({ name, prefix, encode, decode }) =>
   new Codec(name, prefix, encode, decode)
 
 /**
- * @param {string} alphabet
+ * @template {string} Base
+ * @template {string} Prefix
+ * @param {Object} options
+ * @param {Base} options.name
+ * @param {Prefix} options.prefix
+ * @param {string} options.alphabet
+ * @returns {Codec<Base, Prefix>}
  */
-export const implement = (alphabet) => {
-  const { encode, decode } = baseX(alphabet)
-  return {
+export const baseX = ({ prefix, name, alphabet }) => {
+  const { encode, decode } = basex(alphabet, name)
+  return from({
+    prefix,
+    name,
     encode,
     /**
      * @param {string} text
      */
     decode: text => coerce(decode(text))
-  }
+  })
 }
 
 /**
@@ -279,7 +287,7 @@ const decode = (string, alphabet, bitsPerChar, name) => {
     // Read one character from the string:
     const value = codes[string[i]]
     if (value === undefined) {
-      throw new SyntaxError(`invalid ${name} character`)
+      throw new SyntaxError(`Non-${name} character`)
     }
 
     // Append the bits to the buffer:
@@ -295,7 +303,7 @@ const decode = (string, alphabet, bitsPerChar, name) => {
 
   // Verify that we have received just enough bits:
   if (bits >= bitsPerChar || 0xff & (buffer << (8 - bits))) {
-    throw new SyntaxError('unexpected end of data')
+    throw new SyntaxError('Unexpected end of data')
   }
 
   return out

--- a/src/bases/base10.js
+++ b/src/bases/base10.js
@@ -1,0 +1,7 @@
+import { baseX } from './base.js'
+
+export const base10 = baseX({
+  prefix: '9',
+  name: 'base10',
+  alphabet: '0123456789'
+})

--- a/src/bases/base2.js
+++ b/src/bases/base2.js
@@ -1,0 +1,10 @@
+// @ts-check
+
+import { rfc4648 } from './base.js'
+
+export const base2 = rfc4648({
+  prefix: '0',
+  name: 'base2',
+  alphabet: '01',
+  bitsPerChar: 1
+})

--- a/src/bases/base32.js
+++ b/src/bases/base32.js
@@ -17,14 +17,14 @@ export const base32upper = rfc4648({
 export const base32pad = rfc4648({
   prefix: 'c',
   name: 'base32pad',
-  alphabet: 'abcdefghijklmnopqrstuvwxyz234567',
+  alphabet: 'abcdefghijklmnopqrstuvwxyz234567=',
   bitsPerChar: 5
 })
 
 export const base32padupper = rfc4648({
   prefix: 'C',
   name: 'base32padupper',
-  alphabet: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567',
+  alphabet: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567=',
   bitsPerChar: 5
 })
 
@@ -45,14 +45,14 @@ export const base32hexupper = rfc4648({
 export const base32hexpad = rfc4648({
   prefix: 't',
   name: 'base32hexpad',
-  alphabet: '0123456789abcdefghijklmnopqrstuv',
+  alphabet: '0123456789abcdefghijklmnopqrstuv=',
   bitsPerChar: 5
 })
 
 export const base32hexpadupper = rfc4648({
   prefix: 'T',
   name: 'base32hexpadupper',
-  alphabet: '0123456789ABCDEFGHIJKLMNOPQRSTUV',
+  alphabet: '0123456789ABCDEFGHIJKLMNOPQRSTUV=',
   bitsPerChar: 5
 })
 

--- a/src/bases/base36.js
+++ b/src/bases/base36.js
@@ -1,13 +1,13 @@
-import { from, implement } from './base.js'
+import { baseX } from './base.js'
 
-export const base36 = from({
+export const base36 = baseX({
   prefix: 'k',
   name: 'base36',
-  ...implement('0123456789abcdefghijklmnopqrstuvwxyz')
+  alphabet: '0123456789abcdefghijklmnopqrstuvwxyz'
 })
 
-export const base36upper = from({
+export const base36upper = baseX({
   prefix: 'K',
   name: 'base36upper',
-  ...implement('0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ')
+  alphabet: '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'
 })

--- a/src/bases/base58.js
+++ b/src/bases/base58.js
@@ -1,13 +1,13 @@
-import { from, implement } from './base.js'
+import { baseX } from './base.js'
 
-export const base58btc = from({
+export const base58btc = baseX({
   name: 'base58btc',
   prefix: 'z',
-  ...implement('123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz')
+  alphabet: '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
 })
 
-export const base58flickr = from({
+export const base58flickr = baseX({
   name: 'base58flickr',
   prefix: 'Z',
-  ...implement('123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ')
+  alphabet: '123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ'
 })

--- a/src/bases/base8.js
+++ b/src/bases/base8.js
@@ -1,0 +1,10 @@
+// @ts-check
+
+import { rfc4648 } from './base.js'
+
+export const base8 = rfc4648({
+  prefix: '7',
+  name: 'base8',
+  alphabet: '01234567',
+  bitsPerChar: 3
+})

--- a/src/bases/identity.js
+++ b/src/bases/identity.js
@@ -1,0 +1,11 @@
+// @ts-check
+
+import { from } from './base.js'
+import { fromString, toString } from '../bytes.js'
+
+export const identity = from({
+  prefix: '\x00',
+  name: 'identity',
+  encode: (buf) => toString(buf),
+  decode: (str) => fromString(str)
+})

--- a/src/basics.js
+++ b/src/basics.js
@@ -1,5 +1,9 @@
 // @ts-check
 
+import * as identityBase from './bases/identity.js'
+import * as base2 from './bases/base2.js'
+import * as base8 from './bases/base8.js'
+import * as base10 from './bases/base10.js'
 import * as base16 from './bases/base16.js'
 import * as base32 from './bases/base32.js'
 import * as base36 from './bases/base36.js'
@@ -13,7 +17,7 @@ import * as json from './codecs/json.js'
 
 import { CID, hasher, digest, varint, bytes } from './index.js'
 
-const bases = { ...base16, ...base32, ...base36, ...base58, ...base64 }
+const bases = { ...identityBase, ...base2, ...base8, ...base10, ...base16, ...base32, ...base36, ...base58, ...base64 }
 const hashes = { ...sha2, ...identity }
 const codecs = { raw, json }
 

--- a/test/fixtures/test-throw.js
+++ b/test/fixtures/test-throw.js
@@ -1,0 +1,11 @@
+
+export default function testThrow (fn, message) {
+  try {
+    fn()
+  } catch (e) {
+    if (e.message !== message) throw e
+    return
+  }
+  /* c8 ignore next */
+  throw new Error('Test failed to throw')
+}

--- a/test/test-cid.js
+++ b/test/test-cid.js
@@ -11,6 +11,7 @@ import { sha256, sha512 } from 'multiformats/hashes/sha2'
 import util from 'util'
 import { Buffer } from 'buffer'
 import invalidMultihash from './fixtures/invalid-multihash.js'
+import testThrow from './fixtures/test-throw.js'
 
 const test = it
 
@@ -21,18 +22,6 @@ const same = (actual, expected) => {
   return assert.deepStrictEqual(actual, expected)
 }
 
-// eslint-disable-next-line no-unused-vars
-
-const testThrow = async (fn, message) => {
-  try {
-    await fn()
-  } catch (e) {
-    if (e.message !== message) throw e
-    return
-  }
-  /* c8 ignore next */
-  throw new Error('Test failed to throw')
-}
 const testThrowAny = async fn => {
   try {
     await fn()
@@ -80,7 +69,7 @@ describe('CID', () => {
     })
 
     test('throws on invalid BS58Str multihash ', async () => {
-      const msg = 'Non-base58 character'
+      const msg = 'Non-base58btc character'
       await testThrow(() => CID.parse('QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zIII'), msg)
     })
 

--- a/test/test-multibase-spec.js
+++ b/test/test-multibase-spec.js
@@ -1,0 +1,200 @@
+/* eslint-env mocha */
+'use strict'
+
+import { bases } from 'multiformats/basics'
+import { fromString } from '../src/bytes.js'
+import { deepStrictEqual } from 'assert'
+import testThrow from './fixtures/test-throw.js'
+
+const encoded = [
+  {
+    input: 'Decentralize everything!!',
+    tests: [
+      ['identity', '\x00Decentralize everything!!'],
+      ['base2', '001000100011001010110001101100101011011100111010001110010011000010110110001101001011110100110010100100000011001010111011001100101011100100111100101110100011010000110100101101110011001110010000100100001'],
+      ['base8', '72106254331267164344605543227514510062566312711713506415133463441102'],
+      ['base10', '9429328951066508984658627669258025763026247056774804621697313'],
+      ['base16', 'f446563656e7472616c697a652065766572797468696e672121'],
+      ['base16upper', 'F446563656E7472616C697A652065766572797468696E672121'],
+      ['base32', 'birswgzloorzgc3djpjssazlwmvzhs5dinfxgoijb'],
+      ['base32upper', 'BIRSWGZLOORZGC3DJPJSSAZLWMVZHS5DINFXGOIJB'],
+      ['base32hex', 'v8him6pbeehp62r39f9ii0pbmclp7it38d5n6e891'],
+      ['base32hexupper', 'V8HIM6PBEEHP62R39F9II0PBMCLP7IT38D5N6E891'],
+      ['base32pad', 'cirswgzloorzgc3djpjssazlwmvzhs5dinfxgoijb'],
+      ['base32padupper', 'CIRSWGZLOORZGC3DJPJSSAZLWMVZHS5DINFXGOIJB'],
+      ['base32hexpad', 't8him6pbeehp62r39f9ii0pbmclp7it38d5n6e891'],
+      ['base32hexpadupper', 'T8HIM6PBEEHP62R39F9II0PBMCLP7IT38D5N6E891'],
+      ['base32z', 'het1sg3mqqt3gn5djxj11y3msci3817depfzgqejb'],
+      ['base36', 'k343ixo7d49hqj1ium15pgy1wzww5fxrid21td7l'],
+      ['base36upper', 'K343IXO7D49HQJ1IUM15PGY1WZWW5FXRID21TD7L'],
+      ['base58flickr', 'Ztwe7gVTeK8wswS1gf8hrgAua9fcw9reboD'],
+      ['base58btc', 'zUXE7GvtEk8XTXs1GF8HSGbVA9FCX9SEBPe'],
+      ['base64', 'mRGVjZW50cmFsaXplIGV2ZXJ5dGhpbmchIQ'],
+      ['base64pad', 'MRGVjZW50cmFsaXplIGV2ZXJ5dGhpbmchIQ=='],
+      ['base64url', 'uRGVjZW50cmFsaXplIGV2ZXJ5dGhpbmchIQ'],
+      ['base64urlpad', 'URGVjZW50cmFsaXplIGV2ZXJ5dGhpbmchIQ==']
+    ]
+  },
+  {
+    input: 'yes mani !',
+    tests: [
+      ['identity', '\x00yes mani !'],
+      ['base2', '001111001011001010111001100100000011011010110000101101110011010010010000000100001'],
+      ['base8', '7362625631006654133464440102'],
+      ['base10', '9573277761329450583662625'],
+      ['base16', 'f796573206d616e692021'],
+      ['base16upper', 'F796573206D616E692021'],
+      ['base32', 'bpfsxgidnmfxgsibb'],
+      ['base32upper', 'BPFSXGIDNMFXGSIBB'],
+      ['base32hex', 'vf5in683dc5n6i811'],
+      ['base32hexupper', 'VF5IN683DC5N6I811'],
+      ['base32pad', 'cpfsxgidnmfxgsibb'],
+      ['base32padupper', 'CPFSXGIDNMFXGSIBB'],
+      ['base32hexpad', 'tf5in683dc5n6i811'],
+      ['base32hexpadupper', 'TF5IN683DC5N6I811'],
+      ['base32z', 'hxf1zgedpcfzg1ebb'],
+      ['base36', 'k2lcpzo5yikidynfl'],
+      ['base36upper', 'K2LCPZO5YIKIDYNFL'],
+      ['base58flickr', 'Z7Pznk19XTTzBtx'],
+      ['base58btc', 'z7paNL19xttacUY'],
+      ['base64', 'meWVzIG1hbmkgIQ'],
+      ['base64pad', 'MeWVzIG1hbmkgIQ=='],
+      ['base64url', 'ueWVzIG1hbmkgIQ'],
+      ['base64urlpad', 'UeWVzIG1hbmkgIQ==']
+    ]
+  },
+  {
+    input: 'hello world',
+    tests: [
+      ['identity', '\x00hello world'],
+      ['base2', '00110100001100101011011000110110001101111001000000111011101101111011100100110110001100100'],
+      ['base8', '7320625543306744035667562330620'],
+      ['base10', '9126207244316550804821666916'],
+      ['base16', 'f68656c6c6f20776f726c64'],
+      ['base16upper', 'F68656C6C6F20776F726C64'],
+      ['base32', 'bnbswy3dpeb3w64tmmq'],
+      ['base32upper', 'BNBSWY3DPEB3W64TMMQ'],
+      ['base32hex', 'vd1imor3f41rmusjccg'],
+      ['base32hexupper', 'VD1IMOR3F41RMUSJCCG'],
+      ['base32pad', 'cnbswy3dpeb3w64tmmq======'],
+      ['base32padupper', 'CNBSWY3DPEB3W64TMMQ======'],
+      ['base32hexpad', 'td1imor3f41rmusjccg======'],
+      ['base32hexpadupper', 'TD1IMOR3F41RMUSJCCG======'],
+      ['base32z', 'hpb1sa5dxrb5s6hucco'],
+      ['base36', 'kfuvrsivvnfrbjwajo'],
+      ['base36upper', 'KFUVRSIVVNFRBJWAJO'],
+      ['base58flickr', 'ZrTu1dk6cWsRYjYu'],
+      ['base58btc', 'zStV1DL6CwTryKyV'],
+      ['base64', 'maGVsbG8gd29ybGQ'],
+      ['base64pad', 'MaGVsbG8gd29ybGQ='],
+      ['base64url', 'uaGVsbG8gd29ybGQ'],
+      ['base64urlpad', 'UaGVsbG8gd29ybGQ=']
+    ]
+  },
+  {
+    input: '\x00yes mani !',
+    tests: [
+      ['identity', '\x00\x00yes mani !'],
+      ['base2', '00000000001111001011001010111001100100000011011010110000101101110011010010010000000100001'],
+      ['base8', '7000745453462015530267151100204'],
+      ['base10', '90573277761329450583662625'],
+      ['base16', 'f00796573206d616e692021'],
+      ['base16upper', 'F00796573206D616E692021'],
+      ['base32', 'bab4wk4zanvqw42jaee'],
+      ['base32upper', 'BAB4WK4ZANVQW42JAEE'],
+      ['base32hex', 'v01smasp0dlgmsq9044'],
+      ['base32hexupper', 'V01SMASP0DLGMSQ9044'],
+      ['base32pad', 'cab4wk4zanvqw42jaee======'],
+      ['base32padupper', 'CAB4WK4ZANVQW42JAEE======'],
+      ['base32hexpad', 't01smasp0dlgmsq9044======'],
+      ['base32hexpadupper', 'T01SMASP0DLGMSQ9044======'],
+      ['base32z', 'hybhskh3ypiosh4jyrr'],
+      ['base36', 'k02lcpzo5yikidynfl'],
+      ['base36upper', 'K02LCPZO5YIKIDYNFL'],
+      ['base58flickr', 'Z17Pznk19XTTzBtx'],
+      ['base58btc', 'z17paNL19xttacUY'],
+      ['base64', 'mAHllcyBtYW5pICE'],
+      ['base64pad', 'MAHllcyBtYW5pICE='],
+      ['base64url', 'uAHllcyBtYW5pICE'],
+      ['base64urlpad', 'UAHllcyBtYW5pICE=']
+    ]
+  },
+  {
+    input: '\x00\x00yes mani !',
+    tests: [
+      ['identity', '\x00\x00\x00yes mani !'],
+      ['base2', '0000000000000000001111001011001010111001100100000011011010110000101101110011010010010000000100001'],
+      ['base8', '700000171312714403326055632220041'],
+      ['base10', '900573277761329450583662625'],
+      ['base16', 'f0000796573206d616e692021'],
+      ['base16upper', 'F0000796573206D616E692021'],
+      ['base32', 'baaahszltebwwc3tjeaqq'],
+      ['base32upper', 'BAAAHSZLTEBWWC3TJEAQQ'],
+      ['base32hex', 'v0007ipbj41mm2rj940gg'],
+      ['base32hexupper', 'V0007IPBJ41MM2RJ940GG'],
+      ['base32pad', 'caaahszltebwwc3tjeaqq===='],
+      ['base32padupper', 'CAAAHSZLTEBWWC3TJEAQQ===='],
+      ['base32hexpad', 't0007ipbj41mm2rj940gg===='],
+      ['base32hexpadupper', 'T0007IPBJ41MM2RJ940GG===='],
+      ['base32z', 'hyyy813murbssn5ujryoo'],
+      ['base36', 'k002lcpzo5yikidynfl'],
+      ['base36upper', 'K002LCPZO5YIKIDYNFL'],
+      ['base58flickr', 'Z117Pznk19XTTzBtx'],
+      ['base58btc', 'z117paNL19xttacUY'],
+      ['base64', 'mAAB5ZXMgbWFuaSAh'],
+      ['base64pad', 'MAAB5ZXMgbWFuaSAh'],
+      ['base64url', 'uAAB5ZXMgbWFuaSAh'],
+      ['base64urlpad', 'UAAB5ZXMgbWFuaSAh']
+    ]
+  },
+  {
+    input: 'hello world',
+    tests: [
+      ['base16', 'f68656c6c6f20776f726c64'],
+      ['base16upper', 'F68656C6C6F20776F726C64'],
+      ['base32', 'bnbswy3dpeb3w64tmmq'],
+      ['base32upper', 'BNBSWY3DPEB3W64TMMQ'],
+      ['base32hex', 'vd1imor3f41rmusjccg'],
+      ['base32hexupper', 'VD1IMOR3F41RMUSJCCG'],
+      ['base32pad', 'cnbswy3dpeb3w64tmmq======'],
+      ['base32padupper', 'CNBSWY3DPEB3W64TMMQ======'],
+      ['base32hexpad', 'td1imor3f41rmusjccg======'],
+      ['base32hexpadupper', 'TD1IMOR3F41RMUSJCCG======'],
+      ['base36', 'kfuvrsivvnfrbjwajo'],
+      ['base36upper', 'KFUVRSIVVNFRBJWAJO']
+    ]
+  }
+]
+
+describe('spec test', () => {
+  let index = 0
+  for (const { input, tests } of encoded) {
+    describe(`multibase spec ${index++}`, () => {
+      for (const [name, output] of tests) {
+        const base = bases[name]
+
+        describe(name, () => {
+          it('should encode buffer', () => {
+            const out = base.encode(fromString(input))
+            deepStrictEqual(out, output)
+          })
+
+          it('should decode string', () => {
+            deepStrictEqual(base.decode(output), fromString(input))
+          })
+        })
+      }
+    })
+  }
+
+  for (const base of Object.values(bases)) {
+    it('should fail decode with invalid char', function () {
+      if (base.name === 'identity') {
+        return this.skip()
+      }
+
+      console.info('expect', `Non-${base.name} character`)
+      testThrow(() => base.decode(base.prefix + '^!@$%!#$%@#y'), `Non-${base.name} character`)
+    })
+  }
+})

--- a/test/test-multibase.js
+++ b/test/test-multibase.js
@@ -1,27 +1,20 @@
 /* globals describe, it */
 import * as bytes from '../src/bytes.js'
 import assert from 'assert'
+import * as b2 from 'multiformats/bases/base2'
+import * as b8 from 'multiformats/bases/base8'
+import * as b10 from 'multiformats/bases/base10'
 import * as b16 from 'multiformats/bases/base16'
 import * as b32 from 'multiformats/bases/base32'
 import * as b36 from 'multiformats/bases/base36'
 import * as b58 from 'multiformats/bases/base58'
 import * as b64 from 'multiformats/bases/base64'
+import testThrow from './fixtures/test-throw.js'
 
 const { base16, base32, base58btc, base64 } = { ...b16, ...b32, ...b58, ...b64 }
 
 const same = assert.deepStrictEqual
 const test = it
-
-const testThrow = (fn, message) => {
-  try {
-    fn()
-  } catch (e) {
-    if (e.message !== message) throw e
-    return
-  }
-  /* c8 ignore next */
-  throw new Error('Test failed to throw')
-}
 
 describe('multibase', () => {
   for (const base of [base16, base32, base58btc, base64]) {
@@ -46,7 +39,7 @@ describe('multibase', () => {
       })
       test('bad chars', () => {
         const str = base.prefix + '#$%^&*&^%$#'
-        const msg = base === base58btc ? 'Non-base58 character' : `invalid ${base.name} character`
+        const msg = `Non-${base.name} character`
         testThrow(() => base.decode(str), msg)
       })
     })
@@ -88,6 +81,15 @@ describe('multibase', () => {
       }
     }
   }
+  describe('base2', () => {
+    baseTest(b2)
+  })
+  describe('base8', () => {
+    baseTest(b8)
+  })
+  describe('base10', () => {
+    baseTest(b10)
+  })
   describe('base16', () => {
     baseTest(b16)
   })
@@ -133,6 +135,6 @@ describe('multibase', () => {
   test('truncated data', () => {
     const b64 = base64.encode(Uint8Array.from([245, 250]))
 
-    testThrow(() => base64.decode(b64.substring(0, b64.length - 1)), 'unexpected end of data')
+    testThrow(() => base64.decode(b64.substring(0, b64.length - 1)), 'Unexpected end of data')
   })
 })

--- a/test/test-multicodec.js
+++ b/test/test-multicodec.js
@@ -3,20 +3,10 @@ import * as bytes from '../src/bytes.js'
 import assert from 'assert'
 import * as raw from 'multiformats/codecs/raw'
 import * as json from 'multiformats/codecs/json'
+import testThrow from './fixtures/test-throw.js'
 
 const same = assert.deepStrictEqual
 const test = it
-
-const testThrow = async (fn, message) => {
-  try {
-    await fn()
-  } catch (e) {
-    if (e.message !== message) throw e
-    return
-  }
-  /* c8 ignore next */
-  throw new Error('Test failed to throw')
-}
 
 describe('multicodec', () => {
   test('encode/decode raw', () => {

--- a/vendor/base-x.d.ts
+++ b/vendor/base-x.d.ts
@@ -1,4 +1,4 @@
-declare function base(ALPHABET: string): base.BaseConverter;
+declare function base(ALPHABET: string, name: string): base.BaseConverter;
 export = base;
 declare namespace base {
     interface BaseConverter {

--- a/vendor/base-x.js
+++ b/vendor/base-x.js
@@ -3,7 +3,7 @@
 // Copyright (c) 2014-2018 The Bitcoin Core developers (base58.cpp)
 // Distributed under the MIT software license, see the accompanying
 // file LICENSE or http://www.opensource.org/licenses/mit-license.php.
-function base (ALPHABET) {
+function base (ALPHABET, name) {
   if (ALPHABET.length >= 255) { throw new TypeError('Alphabet too long') }
   var BASE_MAP = new Uint8Array(256);
   for (var j = 0; j < BASE_MAP.length; j++) {
@@ -112,7 +112,7 @@ function base (ALPHABET) {
   function decode (string) {
     var buffer = decodeUnsafe(string);
     if (buffer) { return buffer }
-    throw new Error('Non-base' + BASE + ' character')
+    throw new Error(`Non-${name} character`)
   }
   return {
     encode: encode,


### PR DESCRIPTION
1. ports spec tests from js-multibase
2. adds missing identity/base2/8/10 base encodings
3. Standardises error messages - before you might get `'invalid base32upper character'` or `'Non-base32 character'` depending on if rfc4648 or base-x was used (also notice the base name change in the error message), now you always get `'Non-base32upper character'`