### PR TITLE
feat(cid): add symbol like js-cids for detect cid object

### DIFF
--- a/src/cid.js
+++ b/src/cid.js
@@ -4,6 +4,8 @@ import { base58btc } from './bases/base58.js'
 import { base32 } from './bases/base32.js'
 import { coerce } from './bytes.js'
 
+const symbol = Symbol.for('@ipld/js-multiformats/CID')
+
 /**
  * @typedef {import('./hashes/interface').MultihashDigest} MultihashDigest
  * @typedef {0 | 1} CIDVersion
@@ -59,6 +61,8 @@ export class CID {
       _baseCache: hidden,
       asCID: hidden
     })
+    
+    Object.defineProperty(this, symbol, { value: true })
   }
 
   /**


### PR DESCRIPTION
js-multiformats cid vs js-cid cid is too conflict

pls allow this for check when we didn't know current cid is form js-cid or js-multiformats