### PR TITLE
fix: adjust codec exports to make TS defn's more correct

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,18 +96,18 @@
     }
   },
   "devDependencies": {
-    "@types/node": "^16.0.0",
-    "@typescript-eslint/eslint-plugin": "^4.22.0",
-    "@typescript-eslint/parser": "^4.22.0",
+    "@types/node": "^16.7.10",
+    "@typescript-eslint/eslint-plugin": "^4.30.0",
+    "@typescript-eslint/parser": "^4.30.0",
     "buffer": "^6.0.3",
-    "c8": "^7.7.1",
-    "cids": "^1.1.6",
-    "hundreds": "0.0.9",
-    "ipjs": "^5.0.3",
-    "mocha": "^9.0.0",
+    "c8": "^7.8.0",
+    "cids": "^1.1.9",
+    "hundreds": "^0.0.9",
+    "ipjs": "^5.1.0",
+    "mocha": "^9.1.1",
     "polendina": "^1.1.0",
     "standard": "^16.0.3",
-    "typescript": "^4.2.4"
+    "typescript": "^4.4.2"
   },
   "standard": {
     "ignore": [

--- a/src/codecs/json.js
+++ b/src/codecs/json.js
@@ -1,18 +1,26 @@
 // @ts-check
 
 /**
- * @template {number} Code
  * @template T
- * @typedef {import('./interface').BlockCodec<Code, T>} BlockCodec
+ * @typedef {import('./interface').ByteView<T>} ByteView
  */
+
+const textEncoder = new TextEncoder()
+const textDecoder = new TextDecoder()
+
+export const name = 'json'
+export const code = 0x0200
 
 /**
  * @template T
- * @type {BlockCodec<0x0200, T>}
+ * @param {T} node
+ * @returns {ByteView<T>}
  */
-export const { name, code, encode, decode } = {
-  name: 'json',
-  code: 0x0200,
-  encode: json => new TextEncoder().encode(JSON.stringify(json)),
-  decode: bytes => JSON.parse(new TextDecoder().decode(bytes))
-}
+export const encode = (node) => textEncoder.encode(JSON.stringify(node))
+
+/**
+ * @template T
+ * @param {ByteView<T>} data
+ * @returns {T}
+ */
+export const decode = (data) => JSON.parse(textDecoder.decode(data))

--- a/src/codecs/raw.js
+++ b/src/codecs/raw.js
@@ -3,24 +3,21 @@
 import { coerce } from '../bytes.js'
 
 /**
- * @template {number} Code
  * @template T
- * @typedef {import('./interface').BlockCodec<Code, T>} BlockCodec
+ * @typedef {import('./interface').ByteView<T>} ByteView
  */
 
+export const name = 'raw'
+export const code = 0x55
+
 /**
- * @param {Uint8Array} bytes
+ * @param {Uint8Array} node
+ * @returns {ByteView<Uint8Array>}
+ */
+export const encode = (node) => coerce(node)
+
+/**
+ * @param {ByteView<Uint8Array>} data
  * @returns {Uint8Array}
  */
-const raw = (bytes) => coerce(bytes)
-
-/**
- * @template T
- * @type {BlockCodec<0x55, Uint8Array>}
- */
-export const { name, code, encode, decode } = {
-  name: 'raw',
-  code: 0x55,
-  decode: raw,
-  encode: raw
-}
+export const decode = (data) => coerce(data)


### PR DESCRIPTION
(and update deps)
FIxes https://github.com/multiformats/js-multiformats/issues/116 I believe

types/codecs/json.d.ts is now:
```ts
export const name: "json";
export const code: 512;
export function encode<T>(node: T): ByteView<T>;
export function decode<T>(data: ByteView<T>): T;
export type ByteView<T> = import('./interface').ByteView<T>;
//# sourceMappingURL=json.d.ts.map
```

(previous is https://unpkg.com/browse/multiformats@9.4.6/types/codecs/json.d.ts)

types/codecs/raw.d.ts is now:

```ts
/**
 * @template T
 * @typedef {import('./interface').ByteView<T>} ByteView
 */
export const name: "raw";
export const code: 85;
export function encode(node: Uint8Array): ByteView<Uint8Array>;
export function decode(data: ByteView<Uint8Array>): Uint8Array;
export type ByteView<T> = import('./interface').ByteView<T>;
//# sourceMappingURL=raw.d.ts.map
```

(previous is https://unpkg.com/browse/multiformats@9.4.6/types/codecs/raw.d.ts)

I don't know why raw.d.ts gets the jsdoc insert while json.d.ts doesn't, but I'm hoping that doesn't matter since we're getting `encode<T>` and `decode<T>` on json.d.ts where it matters.

/cc @woss 