### PR TITLE
fix(bases): fix typescript failures on computed properties

### DIFF
--- a/test/test-multibase.js
+++ b/test/test-multibase.js
@@ -130,6 +130,14 @@ describe('multibase', () => {
 
     // original composition stays intact
     testThrow(() => base.decode(b64), msg)
+
+    // non-composed combined with composed
+    const baseExt2 = base32.decoder.or(base64.decoder.or(base16.decoder))
+    same(baseExt2.decode(b64), bytes.fromString('test'))
+
+    // composed combined with composed
+    const baseExt3 = base.or(base64.decoder.or(base16.decoder))
+    same(baseExt3.decode(b64), bytes.fromString('test'))
   })
 
   test('truncated data', () => {


### PR DESCRIPTION
Fixing type checks that are now failing, see https://github.com/multiformats/js-multiformats/runs/4266338285?check_suite_focus=true

It's having fresh problems with computed properties building a `Record`, who knows why, I can't find an issue talking about it so am just accepting that this is a new reality for us to deal with and we have to jump through new hoops. This fix is the best I could come up with, it's not ideal and quite verbose, but works.

I moved typedefs to the top, that's not part of the fix, just trying to maintain a convention.