### PR TITLE
fix: add .or method to types

### DIFF
--- a/src/bases/interface.ts
+++ b/src/bases/interface.ts
@@ -74,6 +74,11 @@ export interface MultibaseDecoder<Prefix extends string> {
    * @param multibase
    */
   decode(multibase: Multibase<Prefix>): Uint8Array
+
+  /**
+   * Compose a new MultibaseDecoder that supports either prefix
+   */
+   or <T extends string> (other: MultibaseDecoder<T>): MultibaseDecoder<Prefix | T>
 }
 
 /**


### PR DESCRIPTION
The `Decoder` class implements a `.or` method but it's not included in any of the interfaces it implements (`MultibaseDecoder`, `UnibaseDecoder` or `BaseDecoder`).

I'm not sure if it belongs on the MultibaseDecoder interface, but the things that are exported have `prefix`, `name`, `encode` and `decode` props which make them seem like `MultibaseCodec`s and the `decode` prop of a `MultibaseCodec` is a `MultibaseDecoder` so that's why I put the `.or` definition there.