### PR TITLE
Feat/ts on tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,8 @@
     "@ipld/dag-pb": "^2.1.14",
     "@stablelib/sha256": "^1.0.1",
     "@stablelib/sha512": "^1.0.1",
+    "@types/chai": "^4.3.0",
+    "@types/mocha": "^9.0.0",
     "@types/node": "^17.0.0",
     "@typescript-eslint/eslint-plugin": "^5.6.0",
     "@typescript-eslint/parser": "^5.6.0",
@@ -114,7 +116,7 @@
     "mocha": "^9.1.3",
     "polendina": "^2.0.0",
     "standard": "^16.0.4",
-    "typescript": "^4.5.2"
+    "typescript": "^4.5.4"
   },
   "standard": {
     "ignore": [

--- a/src/bases/base.js
+++ b/src/bases/base.js
@@ -352,7 +352,7 @@ const encode = (data, alphabet, bitsPerChar) => {
 
 /**
  * RFC4648 Factory
- * 
+ *
  * @template {string} Base
  * @template {string} Prefix
  * @param {Object} options

--- a/src/bases/base.js
+++ b/src/bases/base.js
@@ -352,10 +352,12 @@ const encode = (data, alphabet, bitsPerChar) => {
 
 /**
  * RFC4648 Factory
- *
+ * 
+ * @template {string} Base
+ * @template {string} Prefix
  * @param {Object} options
- * @param {string} options.name
- * @param {string} options.prefix
+ * @param {Base} options.name
+ * @param {Prefix} options.prefix
  * @param {string} options.alphabet
  * @param {number} options.bitsPerChar
  */

--- a/test/fixtures/test-throw.js
+++ b/test/fixtures/test-throw.js
@@ -1,9 +1,27 @@
-
-export default function testThrow (fn, message) {
+/**
+ * @param {Function} fn
+ * @param {string} message
+ */
+export const testThrowSync = (fn, message) => {
   try {
     fn()
   } catch (e) {
-    if (e.message !== message) throw e
+    if (/** @type {Error} */(e).message !== message) throw e
+    return
+  }
+  /* c8 ignore next */
+  throw new Error('Test failed to throw')
+}
+
+/**
+ * @param {Function} fn
+ * @param {string} message
+ */
+export const testThrowAsync = async (fn, message) => {
+  try {
+    await fn()
+  } catch (e) {
+    if (/** @type {Error} */(e).message !== message) throw e
     return
   }
   /* c8 ignore next */

--- a/test/test-bytes.js
+++ b/test/test-bytes.js
@@ -4,8 +4,8 @@ import { assert } from 'chai'
 
 describe('bytes', () => {
   it('isBinary', () => {
-    assert.deepStrictEqual(bytes.isBinary(new ArrayBuffer()), true)
-    assert.deepStrictEqual(bytes.isBinary(new DataView(new ArrayBuffer())), true)
+    assert.deepStrictEqual(bytes.isBinary(new ArrayBuffer(0)), true)
+    assert.deepStrictEqual(bytes.isBinary(new DataView(new ArrayBuffer(0))), true)
   })
 
   it('coerce', () => {

--- a/test/test-multibase-spec.js
+++ b/test/test-multibase-spec.js
@@ -4,7 +4,7 @@
 import { bases } from 'multiformats/basics'
 import { fromString } from '../src/bytes.js'
 import { assert } from 'chai'
-import testThrow from './fixtures/test-throw.js'
+import { testThrowSync as testThrow } from './fixtures/test-throw.js'
 
 const encoded = [
   {
@@ -171,7 +171,7 @@ describe('spec test', () => {
   for (const { input, tests } of encoded) {
     describe(`multibase spec ${index++}`, () => {
       for (const [name, output] of tests) {
-        const base = bases[name]
+        const base = bases[/** @type {keyof bases} */(name)]
 
         describe(name, () => {
           it('should encode buffer', () => {

--- a/test/test-multibase.js
+++ b/test/test-multibase.js
@@ -9,7 +9,7 @@ import * as b32 from 'multiformats/bases/base32'
 import * as b36 from 'multiformats/bases/base36'
 import * as b58 from 'multiformats/bases/base58'
 import * as b64 from 'multiformats/bases/base64'
-import testThrow from './fixtures/test-throw.js'
+import { testThrowAsync as testThrow } from './fixtures/test-throw.js'
 
 const { base16, base32, base58btc, base64 } = { ...b16, ...b32, ...b58, ...b64 }
 
@@ -47,19 +47,26 @@ describe('multibase', () => {
 
   it('encode string failure', () => {
     const msg = 'Unknown type, must be binary type'
+    // @ts-expect-error - expects bytes
     testThrow(() => base32.encode('asdf'), msg)
+    // @ts-expect-error - expects bytes
     testThrow(() => base32.encoder.encode('asdf'), msg)
   })
 
   it('decode int failure', () => {
     const msg = 'Can only multibase decode strings'
+    // @ts-expect-error - 'number' is not assignable to parameter of type 'string'
     testThrow(() => base32.decode(1), msg)
+    // @ts-expect-error - 'number' is not assignable to parameter of type 'string'
     testThrow(() => base32.decoder.decode(1), msg)
   })
 
   const buff = bytes.fromString('test')
   const nonPrintableBuff = Uint8Array.from([239, 250, 254])
 
+  /**
+   * @param {typeof b2|b8|b10|b16|b32|b36|b58|b64} bases
+   */
   const baseTest = bases => {
     for (const base of Object.values(bases)) {
       if (base && base.name) {
@@ -152,5 +159,20 @@ describe('multibase', () => {
     const b64 = base64.encode(Uint8Array.from([245, 250]))
 
     testThrow(() => base64.decode(b64.substring(0, b64.length - 1)), 'Unexpected end of data')
+  })
+
+  it('infers prefix and name corretly', () => {
+    /** @type {'base32'} */
+    const name = base32.name
+
+    /** @type {'base16'} */
+    // @ts-expect-error - TS catches mismatch
+    const name2 = base32.name
+
+    /** @type {'b'} */
+    const prefix = base32.prefix
+    assert.equal(prefix, 'b')
+    assert.equal(name, 'base32')
+    assert.equal(name2, name)
   })
 })

--- a/test/test-multicodec.js
+++ b/test/test-multicodec.js
@@ -3,13 +3,13 @@ import * as bytes from '../src/bytes.js'
 import { assert } from 'chai'
 import * as raw from 'multiformats/codecs/raw'
 import * as json from 'multiformats/codecs/json'
-import testThrow from './fixtures/test-throw.js'
+import { testThrowAsync } from './fixtures/test-throw.js'
 
 describe('multicodec', () => {
   it('encode/decode raw', () => {
     const buff = raw.encode(bytes.fromString('test'))
     assert.deepStrictEqual(buff, bytes.fromString('test'))
-    assert.deepStrictEqual(raw.decode(buff, 'raw'), bytes.fromString('test'))
+    assert.deepStrictEqual(raw.decode(buff), bytes.fromString('test'))
   })
 
   it('encode/decode json', () => {
@@ -19,6 +19,7 @@ describe('multicodec', () => {
   })
 
   it('raw cannot encode string', async () => {
-    await testThrow(() => raw.encode('asdf'), 'Unknown type, must be binary type')
+    // @ts-expect-error - 'string' is not assignable to parameter of type 'Uint8Array'
+    await testThrowAsync(() => raw.encode('asdf'), 'Unknown type, must be binary type')
   })
 })

--- a/test/test-multihash.js
+++ b/test/test-multihash.js
@@ -8,25 +8,23 @@ import invalid from './fixtures/invalid-multihash.js'
 import { sha256, sha512 } from 'multiformats/hashes/sha2'
 import { identity } from 'multiformats/hashes/identity'
 import { decode as decodeDigest, create as createDigest } from 'multiformats/hashes/digest'
+import { testThrowAsync } from './fixtures/test-throw.js'
 
+/**
+ * @param {number|string} code
+ * @param {number} size
+ * @param {string} hex
+ */
 const sample = (code, size, hex) => {
+  /**
+   * @param {number|string} i
+   */
   const toHex = (i) => {
     if (typeof i === 'string') return i
     const h = i.toString(16)
     return h.length % 2 === 1 ? `0${h}` : h
   }
   return fromHex(`${toHex(code)}${toHex(size)}${hex}`)
-}
-
-const testThrowAsync = async (fn, message) => {
-  try {
-    await fn()
-  } catch (e) {
-    if (e.message !== message) throw e
-    return
-  }
-  /* c8 ignore next */
-  throw new Error('Test failed to throw')
 }
 
 describe('multihash', () => {
@@ -104,6 +102,7 @@ describe('multihash', () => {
   })
 
   it('throw on hashing non-buffer', async () => {
+    // @ts-expect-error - string is incompatible arg
     await testThrowAsync(() => sha256.digest('asdf'), 'Unknown type, must be binary type')
   })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "strict": true,
     "alwaysStrict": true,
     "esModuleInterop": true,
-    "target": "ES2018",
+    "target": "ES2020",
     "moduleResolution": "node",
     "declaration": true,
     "declarationMap": true,
@@ -26,18 +26,86 @@
     "resolveJsonModule": true,
     "emitDeclarationOnly": true,
     "baseUrl": ".",
+    // unfortunately we have to manually path map each file so that
+    // ts can resolve imports correctly (which workarounds resolution
+    // occuring from node_modules/multiformats which is installed by dev
+    // dependency)
+    // Once https://www.typescriptlang.org/docs/handbook/esm-node.html
+    // is stabilized we will no longer need this hack.
     "paths": {
       "multiformats": [
-        "src"
+        "src/index.js"
+      ],
+      "multiformats/cid": [
+        "./src/cid.js"
+      ],
+      "multiformats/basics": [
+        "./src/basics.js"
+      ],
+      "multiformats/block": [
+        "./src/block.js"
+      ],
+      "multiformats/traversal": [
+        "./src/traversal.js"
+      ],
+      "multiformats/bases/identity": [
+        "./src/bases/identity.js"
+      ],
+      "multiformats/bases/base2": [
+        "./src/bases/base2.js"
+      ],
+      "multiformats/bases/base8": [
+        "./src/bases/base8.js"
+      ],
+      "multiformats/bases/base10": [
+        "./src/bases/base10.js"
+      ],
+      "multiformats/bases/base16": [
+        "./src/bases/base16.js"
+      ],
+      "multiformats/bases/base32": [
+        "./src/bases/base32.js"
+      ],
+      "multiformats/bases/base36": [
+        "./src/bases/base36.js"
+      ],
+      "multiformats/bases/base58": [
+        "./src/bases/base58.js"
+      ],
+      "multiformats/bases/base64": [
+        "./src/bases/base64.js"
+      ],
+      "multiformats/hashes/hasher": [
+        "./src/hashes/hasher.js"
+      ],
+      "multiformats/hashes/digest": [
+        "./src/hashes/digest.js"
+      ],
+      "multiformats/hashes/sha2": [
+        "./src/hashes/sha2-browser.js"
+      ],
+      "multiformats/hashes/identity": [
+        "./src/hashes/identity.js"
+      ],
+      "multiformats/codecs/json": [
+        "./src/codecs/json.js"
+      ],
+      "multiformats/codecs/raw": [
+        "src/codecs/raw.js"
+      ],
+      "multiformats/*": [
+        "src/*"
       ]
     }
   },
   "include": [
-    "src"
+    "src",
+    "test"
   ],
   "exclude": [
     "vendor",
-    "node_modules"
+    "node_modules",
+    "node_modules/multiformats"
   ],
   "compileOnSave": false
 }


### PR DESCRIPTION
This change enables TS on tests. Did that because as I was trying to figure out #141 I did notice that some type inference degraded, which is unsurprising if we are not verifying things.

This pull also fixes b32 types and adds some tests to ensure that inference works as expected.