### PR TITLE
feat: add truncate method to cid.js

### DIFF
--- a/src/cid.js
+++ b/src/cid.js
@@ -138,6 +138,14 @@ export class CID {
     }
   }
 
+  /**
+   * @param {string} cidString
+   * @returns {string}
+   */
+  truncate (cidString) {
+    return `${cidString.substr(0, 4)}...${cidString.substr(cidString.length - 4, cidString.length)}`
+  }
+
   get [Symbol.toStringTag] () {
     return 'CID'
   }

--- a/test/test-cid.js
+++ b/test/test-cid.js
@@ -392,6 +392,13 @@ describe('CID', () => {
     assert.ok(equals(json.hash, hash.bytes))
   })
 
+  it('truncate()', async () => {
+    const cidString = 'QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR'
+    const truncatedCidString = CID.truncate(cidString)
+
+    assert.ok(equals(truncatedCidString, 'QmbW...sMnR'))    
+  })
+
   it('isCID', async () => {
     const hash = await sha256.digest(textEncoder.encode('abc'))
     const cid = CID.create(1, 112, hash)


### PR DESCRIPTION
**TLDR** _Adds a truncate method that when passed a CID returns the first 4 characters, "...", and the last 4 characters._


This came out of a discussion in the filecoin slack with @mikeal and @lidel.

We need a way to convey to users that the DApp they are using is decentralized. Etherlink achieves this by displaying a truncated version of the address.

We want to do something similiar as discussed here:
https://protocollabs.notion.site/Displaying-IPFS-87c9287848e746f898d0e058c3649633

According to @lidel we already have an established convention:

>I think we established some conventions in ipfs-webui and ipld explorer.
Namely:
>* CID is what matters
>* CIDs can be truncated by dropping the middle of it, and keeping 4 characters on each end (bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq → bafy...vhwq)

>As for  linking, Just link to https://dweb.link/ipfs/CID – it works everywhere, and IPFS-capable user agent will provide upgrade path to native IPFS (eg. Companion will redirect, Brave will show a badge in address bar etc)
So the "Details" sections like one on the screenshot above would have something like: `IPFS CID: bafy...vhwq`


https://filecoinproject.slack.com/archives/C02EQ3ELFBQ/p1639435200126600?thread_ts=1639033925.100700&cid=C02EQ3ELFBQ

This PR implements this simple method.