### PR TITLE
fix(types): fix publishing of types

### DIFF
--- a/src/traversal.js
+++ b/src/traversal.js
@@ -1,4 +1,4 @@
-import { base58btc } from 'multiformats/bases/base58'
+import { base58btc } from './bases/base58.js'
 
 /**
  * @typedef {import('./cid.js').CID} CID

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -99,8 +99,7 @@
     }
   },
   "include": [
-    "src",
-    "test"
+    "src"
   ],
   "exclude": [
     "vendor",


### PR DESCRIPTION
I'm presuming this is a temporary fix in tsconfig.json, removing "tests" for
now to get back the old behaviour of just publishing src/ -> types/ rather
than having both src/ and tests/ both in types/ as subdirectories which
breaks types mappings.