### PR TITLE
Reanable tsc action and reconfigure project slightly

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,27 @@
+on:
+  push:
+    branches:
+      - master
+      - main
+      - default
+  pull_request:
+    branches:
+      - '**'
+
+name: Typecheck
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+      - uses: actions/checkout@v2.4.0
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2.5.1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install dependencies
+        run: npm install
+      - name: Typecheck
+        uses: gozala/typescript-error-reporter-action@v1.0.8

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -6,7 +6,7 @@ on:
       - default
   pull_request:
     branches:
-      - '**'
+      - "**"
 
 name: Typecheck
 jobs:
@@ -25,3 +25,5 @@ jobs:
         run: npm install
       - name: Typecheck
         uses: gozala/typescript-error-reporter-action@v1.0.8
+        with:
+          project: test/tsconfig.json

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0-dev",
   "description": "Interface for multihash, multicodec, multibase and CID",
   "main": "./src/index.js",
-  "types": "./types/index.d.ts",
+  "types": "./types/src/index.d.ts",
   "type": "module",
   "scripts": {
     "build": "npm run build:js && npm run build:types",
@@ -21,6 +21,7 @@
     "test:esm:browser": "polendina --page --worker --serviceworker --cleanup dist/esm/browser-test/test-*.js",
     "test:ts": "npm run build:types && npm run test --prefix test/ts-use",
     "test": "npm run lint && npm run test:node && npm run test:esm && npm run test:ts",
+    "typecheck": "tsc --build test/tsconfig.json",
     "test:ci": "npm run lint && npm run test:node && npm run test:esm && npm run test:cjs && npm run test:ts",
     "coverage": "c8 --reporter=html mocha test/test-*.js && npm_config_yes=true npx st -d coverage -p 8080"
   },
@@ -140,7 +141,7 @@
   "typesVersions": {
     "*": {
       "*": [
-        "types/*"
+        "types/src/*"
       ],
       "types/*": [
         "types/*"

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "build": "npm run build:js && npm run build:types",
     "build:js": "ipjs build --tests --main && npm run build:copy",
-    "build:copy": "cp -a src vendor test dist/ && rm -rf dist/test/ts-use",
-    "build:types": "npm run build:copy && cd dist && tsc --build src/tsconfig.json test/tsconfig.json",
+    "build:copy": "cp -a tsconfig.json src vendor test dist/ && rm -rf dist/test/ts-use",
+    "build:types": "npm run build:copy && cd dist && tsc --build",
     "build:vendor": "npm run build:vendor:varint && npm run build:vendor:base-x",
     "build:vendor:varint": "npm_config_yes=true npx brrp -x varint > vendor/varint.js",
     "build:vendor:base-x": "npm_config_yes=true npx brrp -x @multiformats/base-x > vendor/base-x.js",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "test:esm:browser": "polendina --page --worker --serviceworker --cleanup dist/esm/browser-test/test-*.js",
     "test:ts": "npm run build:types && npm run test --prefix test/ts-use",
     "test": "npm run lint && npm run test:node && npm run test:esm && npm run test:ts",
-    "typecheck": "tsc --build test/tsconfig.json",
     "test:ci": "npm run lint && npm run test:node && npm run test:esm && npm run test:cjs && npm run test:ts",
     "coverage": "c8 --reporter=html mocha test/test-*.js && npm_config_yes=true npx st -d coverage -p 8080"
   },

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "references": [
     {
-      "path": "../src/"
+      "path": "../"
     }
   ],
   "compilerOptions": {
@@ -25,19 +25,10 @@
     "moduleResolution": "node",
     "declaration": true,
     "declarationMap": true,
-    "outDir": "../types",
     "skipLibCheck": true,
     "stripInternal": true,
     "resolveJsonModule": true,
-    "noEmit": true,
-    "paths": {
-      "multiformats": [
-        "../src/index.js"
-      ],
-      "multiformats/*": [
-        "../src/*.js"
-      ]
-    }
+    "noEmit": true
   },
   "include": [
     "test/",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,7 @@
     "moduleResolution": "node",
     "declaration": true,
     "declarationMap": true,
-    "outDir": "./types",
+    "outDir": "types",
     "skipLibCheck": true,
     "stripInternal": true,
     "resolveJsonModule": true,
@@ -31,6 +31,9 @@
   "include": [
     "src"
   ],
-  "exclude": [],
+  "exclude": [
+    "vendor",
+    "node_modules"
+  ],
   "compileOnSave": false
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,7 @@
     "moduleResolution": "node",
     "declaration": true,
     "declarationMap": true,
-    "outDir": "../types",
+    "outDir": "./types",
     "skipLibCheck": true,
     "stripInternal": true,
     "resolveJsonModule": true,
@@ -29,7 +29,7 @@
     "composite": true
   },
   "include": [
-    "."
+    "src"
   ],
   "exclude": [],
   "compileOnSave": false


### PR DESCRIPTION
This pull reverts https://github.com/multiformats/js-multiformats/commit/b0467e52870a91f3fc3122afb969505a31dc3210 which reports type errors in the diff view as opposed to just dumping it into output.

It also changes TS configuration as follows:

1. Moves tsconfig.json to the package root from src. That is more idiomatic and removes need for path mapping in tests, because TS now knows that linked multiformats package is project reference.
2. Updates .d.ts paths to include `src`. As it turns out `composite` flag in tsconfig causes dir stracture to be retained & that flag is necessary to enable project references. We do not however generate types for tests though because those aren't included.
3. Github action now points to test/tsconfig.json to type check everything. Because that tsconfig.json references one in the repo root type check will run over src as well.