### PR TITLE
fix: export only `identity` hasher const

### DIFF
--- a/src/hashes/identity.js
+++ b/src/hashes/identity.js
@@ -1,14 +1,14 @@
 import { coerce } from '../bytes.js'
 import * as Digest from './digest.js'
 
-export const code = 0x0
-export const name = 'identity'
+const code = 0x0
+const name = 'identity'
 
 /**
  * @param {Uint8Array} input
  * @returns {Digest.Digest<typeof code, number>}
  */
-export const digest = (input) => Digest.create(code, coerce(input))
+const digest = (input) => Digest.create(code, coerce(input))
 
 /** @type {import('./interface').SyncMultihashHasher<typeof code>} */
 export const identity = { code, name, digest }


### PR DESCRIPTION
basics.js uses `...identity` from the import, so as of 9.6.0 (via #160) `name` and friends get mixed up as hashers, which they are not.

This could be fixed in basics.js, but I think its usage tells us that #160 was a breaking change. So we'll do a revert-ish of the exports, and deal with the interface later with a breaking change if we think that a `*` export of identity (which wouldn't match the sha2 export) is the right way to go.

Fixes: https://github.com/ipfs/js-ipfs/issues/4020