### PR TITLE
fix: add encode to identity

### DIFF
--- a/src/hashes/identity.js
+++ b/src/hashes/identity.js
@@ -6,9 +6,14 @@ const name = 'identity'
 
 /**
  * @param {Uint8Array} input
+ * @returns {Uint8Array}
+ */
+const encode = (input) => coerce(input)
+
+/**
+ * @param {Uint8Array} input
  * @returns {Digest.Digest<typeof code, number>}
  */
 const digest = (input) => Digest.create(code, coerce(input))
 
-/** @type {import('./interface').SyncMultihashHasher<typeof code>} */
-export const identity = { code, name, digest }
+export const identity = { code, name, encode, digest }

--- a/src/hashes/identity.js
+++ b/src/hashes/identity.js
@@ -4,16 +4,13 @@ import * as Digest from './digest.js'
 const code = 0x0
 const name = 'identity'
 
-/**
- * @param {Uint8Array} input
- * @returns {Uint8Array}
- */
-const encode = (input) => coerce(input)
+/** @type {(input:Uint8Array) => Uint8Array} */
+const encode = coerce
 
 /**
  * @param {Uint8Array} input
  * @returns {Digest.Digest<typeof code, number>}
  */
-const digest = (input) => Digest.create(code, coerce(input))
+const digest = (input) => Digest.create(code, encode(input))
 
 export const identity = { code, name, encode, digest }


### PR DESCRIPTION
Fix API unintentional API change introduced by #160 which removed `encode` method.