### PR TITLE
feat: add optional offset param to varint.decode

### DIFF
--- a/src/varint.js
+++ b/src/varint.js
@@ -2,10 +2,11 @@ import varint from '../vendor/varint.js'
 
 /**
  * @param {Uint8Array} data
+ * @param {number} [offset=0]
  * @returns {[number, number]}
  */
-export const decode = (data) => {
-  const code = varint.decode(data)
+export const decode = (data, offset = 0) => {
+  const code = varint.decode(data, offset)
   return [code, varint.decode.bytes]
 }
 

--- a/test/test-varint.js
+++ b/test/test-varint.js
@@ -1,0 +1,28 @@
+/* globals describe, it */
+
+import { varint } from 'multiformats'
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+
+chai.use(chaiAsPromised)
+const { assert } = chai
+
+const UTF8 = new TextEncoder()
+
+describe('varint', () => {
+  it('can decode with offset', () => {
+    const message = UTF8.encode('hello-world')
+    const outerTag = 0x55
+    const innerTag = 0xe3
+    const outerTagSize = varint.encodingLength(outerTag)
+    const innerTagSize = varint.encodingLength(innerTag)
+
+    const bytes = new Uint8Array(message.byteLength + outerTagSize + innerTagSize)
+    varint.encodeTo(outerTag, bytes)
+    varint.encodeTo(innerTag, bytes, outerTagSize)
+    bytes.set(message, outerTagSize + innerTagSize)
+
+    assert.deepStrictEqual(varint.decode(bytes), [outerTag, outerTagSize])
+    assert.deepStrictEqual(varint.decode(bytes, outerTagSize), [innerTag, innerTagSize])
+  })
+})


### PR DESCRIPTION
Adds optional `offset` parameter to `varint.decode` to allow decoding varints at arbitrary offsets without having to create intermediary `Uint8Array`s.

Whenever I have to deal with format that puts multiple varints e.g. `<code><size><bytes>` I find myself having to read first varint then to read second I'm forced to create another Uint8Array view. With this change it would be possible to just specify offset and avoid creating unnecessary objects. 