### PR TITLE
fix: remove use of Object.defineProperties in CID class

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,7 +157,8 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
-      "sourceType": "module"
+      "sourceType": "module",
+      "ecmaVersion": 13
     }
   },
   "release": {

--- a/package.json
+++ b/package.json
@@ -157,8 +157,7 @@
   "eslintConfig": {
     "extends": "ipfs",
     "parserOptions": {
-      "sourceType": "module",
-      "ecmaVersion": 13
+      "sourceType": "module"
     }
   },
   "release": {

--- a/src/cid.js
+++ b/src/cid.js
@@ -61,6 +61,9 @@ const baseCache = cid => {
  */
 
 export class CID {
+  /** @type {CID} */
+  #asCID
+
   /**
    * @param {Version} version - Version of the CID
    * @param {Format} code - Code of the codec content is encoded in, see https://github.com/multiformats/multicodec/blob/master/table.csv
@@ -86,20 +89,11 @@ export class CID {
 
     // Circular reference
     /** @readonly */
-    this.asCID = this
+    this.#asCID = this
+  }
 
-    // Configure private properties
-    Object.defineProperties(this, {
-      byteOffset: hidden,
-      byteLength: hidden,
-
-      code: readonly,
-      version: readonly,
-      multihash: readonly,
-      bytes: readonly,
-
-      asCID: hidden
-    })
+  get asCID () {
+    return this.#asCID
   }
 
   /**
@@ -568,5 +562,3 @@ const encodeCID = (version, code, multihash) => {
 }
 
 const cidSymbol = Symbol.for('@ipld/js-cid/CID')
-const readonly = { writable: false, configurable: false, enumerable: true }
-const hidden = { writable: false, enumerable: false, configurable: false }

--- a/src/cid.js
+++ b/src/cid.js
@@ -61,9 +61,6 @@ const baseCache = cid => {
  */
 
 export class CID {
-  /** @type {CID} */
-  #asCID
-
   /**
    * @param {Version} version - Version of the CID
    * @param {Format} code - Code of the codec content is encoded in, see https://github.com/multiformats/multicodec/blob/master/table.csv
@@ -89,11 +86,7 @@ export class CID {
 
     // Circular reference
     /** @readonly */
-    this.#asCID = this
-  }
-
-  get asCID () {
-    return this.#asCID
+    this.asCID = this
   }
 
   /**

--- a/test/test-cid.spec.js
+++ b/test/test-cid.spec.js
@@ -696,4 +696,12 @@ describe('CID', () => {
     const encoded = varint.encodeTo(2, new Uint8Array(32))
     assert.throws(() => CID.decode(encoded), 'Invalid CID version 2')
   })
+
+  it('asCID is non-enumerable', () => {
+    const cid = CID.parse('bafybeif2pall7dybz7vecqka3zo24irdwabwdi4wc55jznaq75q7eaavvu')
+
+    assert.isFalse(Object.prototype.propertyIsEnumerable.call(cid, 'asCID'))
+    assert.isFalse(Object.keys(cid).includes('asCID'))
+    assert.equal(cid.asCID, cid)
+  })
 })

--- a/test/test-cid.spec.js
+++ b/test/test-cid.spec.js
@@ -704,4 +704,14 @@ describe('CID', () => {
     assert.isFalse(Object.keys(cid).includes('asCID'))
     assert.equal(cid.asCID, cid)
   })
+
+  it('CID can be moved across JS realms', async () => {
+    const cid = CID.parse('bafybeif2pall7dybz7vecqka3zo24irdwabwdi4wc55jznaq75q7eaavvu')
+    const { port1: sender, port2: receiver } = new MessageChannel()
+    sender.postMessage(cid)
+    const cid2 = await new Promise((resolve) => {
+      receiver.onmessage = (event) => { resolve(event.data) }
+    })
+    assert.equal(cid2.asCID, cid2)
+  })
 })

--- a/test/test-cid.spec.js
+++ b/test/test-cid.spec.js
@@ -697,14 +697,6 @@ describe('CID', () => {
     assert.throws(() => CID.decode(encoded), 'Invalid CID version 2')
   })
 
-  it('asCID is non-enumerable', () => {
-    const cid = CID.parse('bafybeif2pall7dybz7vecqka3zo24irdwabwdi4wc55jznaq75q7eaavvu')
-
-    assert.isFalse(Object.prototype.propertyIsEnumerable.call(cid, 'asCID'))
-    assert.isFalse(Object.keys(cid).includes('asCID'))
-    assert.equal(cid.asCID, cid)
-  })
-
   it('CID can be moved across JS realms', async () => {
     const cid = CID.parse('bafybeif2pall7dybz7vecqka3zo24irdwabwdi4wc55jznaq75q7eaavvu')
     const { port1: sender, port2: receiver } = new MessageChannel()
@@ -712,6 +704,8 @@ describe('CID', () => {
     const cid2 = await new Promise((resolve) => {
       receiver.onmessage = (event) => { resolve(event.data) }
     })
-    assert.equal(cid2.asCID, cid2)
+    assert.strictEqual(cid2.asCID, cid2)
+    sender.close()
+    receiver.close()
   })
 })


### PR DESCRIPTION
`Object.defineProperties` is a performance bottleneck in applications that create lots and lots of CIDs (e.g. IPFS) so this PR removes it.

The `asCID` property is changed to be a [private class field](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields) which requires increasing the minimum supported EcmaScript version but I don't know if that's a big deal or not.  It does seem to make the property non-enumerable though.

The CID class now implements a new `Link` interface that has public read-only `byteOffset` and `byteLength` properties so these become regular properties.  Similarly `code`, `version`, `multihash` and `bytes` become writable/configurable but they are also marked with `@readonly` so maybe that's enough?

Fixes #200