### PR TITLE
chore: rename varint test file so it is run

### DIFF
--- a/test/test-varint.spec.js
+++ b/test/test-varint.spec.js
@@ -1,11 +1,7 @@
 /* globals describe, it */
 
 import { varint } from '../src/index.js'
-import chai from 'chai'
-import chaiAsPromised from 'chai-as-promised'
-
-chai.use(chaiAsPromised)
-const { assert } = chai
+import { assert } from 'aegir/chai'
 
 const UTF8 = new TextEncoder()
 


### PR DESCRIPTION
Renames file so it's run along with all the other tests.

Before:

```console
  447 passing (613ms)
  1 pending
```

After:

```console
  448 passing (621ms)
  1 pending
```