### PR TITLE
feat!: remove .byteLength and .byteOffset properties from CID

### DIFF
--- a/src/cid.js
+++ b/src/cid.js
@@ -78,12 +78,6 @@ export class CID {
     /** @readonly */
     this.bytes = bytes
 
-    // ArrayBufferView
-    /** @readonly */
-    this.byteOffset = bytes.byteOffset
-    /** @readonly */
-    this.byteLength = bytes.byteLength
-
     // Circular reference
     /** @readonly */
     this.asCID = this
@@ -272,6 +266,10 @@ export class CID {
   static create (version, code, digest) {
     if (typeof code !== 'number') {
       throw new Error('String codecs are no longer supported')
+    }
+
+    if (digest.bytes == null) {
+      throw new Error('Invalid digest')
     }
 
     switch (version) {

--- a/src/link/interface.ts
+++ b/src/link/interface.ts
@@ -27,9 +27,6 @@ export interface Link<
   readonly version: V
   readonly code: Format
   readonly multihash: MultihashDigest<Alg>
-
-  readonly byteOffset: number
-  readonly byteLength: number
   readonly bytes: ByteView<Link<Data, Format, Alg, V>>
 
   equals: (other: unknown) => other is Link<Data, Format, Alg, Version>

--- a/test/test-cid.spec.js
+++ b/test/test-cid.spec.js
@@ -708,4 +708,32 @@ describe('CID', () => {
     sender.close()
     receiver.close()
   })
+
+  describe('decode', () => {
+    const tests = {
+      v0: 'QmTFHZL5CkgNz19MdPnSuyLAi6AVq9fFp81zmPpaL2amED',
+      v1: 'bafybeif2pall7dybz7vecqka3zo24irdwabwdi4wc55jznaq75q7eaavvu'
+    }
+
+    Object.entries(tests).forEach(([version, cidString]) => {
+      it(`decode ${version} from bytes`, () => {
+        const cid1 = CID.parse(cidString)
+        const cid2 = CID.decode(cid1.bytes)
+
+        assert.deepStrictEqual(cid1, cid2)
+      })
+
+      it(`decode ${version} from subarray`, () => {
+        const cid1 = CID.parse(cidString)
+        // a byte array with an extra byte at the start and end
+        const bytes = new Uint8Array(cid1.bytes.length + 2)
+        bytes.set(cid1.bytes, 1)
+        // slice the cid bytes out of the middle to have a subarray with a non-zero .byteOffset
+        const subarray = bytes.subarray(1, cid1.bytes.length + 1)
+        const cid2 = CID.decode(subarray)
+
+        assert.deepStrictEqual(cid1, cid2)
+      })
+    })
+  })
 })


### PR DESCRIPTION
From #203

> I would like to also address byteOffset, byteLength fields. I don't think they were a bad idea, it's just I was not allowed to complete implementation of that idea.

Given that the feature is incomplete, untested and causes assertions elsewhere to fail, remove it for now and if it's required it can be implemented fully in the future.

Fixes #208

BREAKING CHANGE: The CID class no longer has `.byteOffset` and `.byteLength` properties - these can be accessed via the `.bytes` property instead