### PR TITLE
fix: convert byteOffset and byteLength to getters

### DIFF
--- a/src/cid.js
+++ b/src/cid.js
@@ -78,15 +78,19 @@ export class CID {
     /** @readonly */
     this.bytes = bytes
 
-    // ArrayBufferView
-    /** @readonly */
-    this.byteOffset = bytes.byteOffset
-    /** @readonly */
-    this.byteLength = bytes.byteLength
-
     // Circular reference
     /** @readonly */
     this.asCID = this
+  }
+
+  // ArrayBufferView
+  get byteOffset () {
+    return this.bytes.byteOffset
+  }
+
+  // ArrayBufferView
+  get byteLength () {
+    return this.bytes.byteLength
   }
 
   /**
@@ -272,6 +276,10 @@ export class CID {
   static create (version, code, digest) {
     if (typeof code !== 'number') {
       throw new Error('String codecs are no longer supported')
+    }
+
+    if (digest.bytes == null) {
+      throw new Error('Invalid digest')
     }
 
     switch (version) {

--- a/src/cid.js
+++ b/src/cid.js
@@ -278,7 +278,7 @@ export class CID {
       throw new Error('String codecs are no longer supported')
     }
 
-    if (digest.bytes == null) {
+    if (!(digest.bytes instanceof Uint8Array)) {
       throw new Error('Invalid digest')
     }
 

--- a/test/test-cid.spec.js
+++ b/test/test-cid.spec.js
@@ -733,6 +733,8 @@ describe('CID', () => {
         const cid2 = CID.decode(subarray)
 
         assert.deepStrictEqual(cid1, cid2)
+        assert.equal(cid1.byteLength, cid2.byteLength)
+        assert.notEqual(cid1.byteOffset, cid2.byteOffset)
       })
     })
   })

--- a/test/test-cid.spec.js
+++ b/test/test-cid.spec.js
@@ -734,7 +734,7 @@ describe('CID', () => {
 
         assert.deepStrictEqual(cid1, cid2)
         assert.equal(cid1.byteLength, cid2.byteLength)
-        assert.notEqual(cid1.byteOffset, cid2.byteOffset)
+        assert.equal(typeof cid2.byteOffset, 'number')
       })
     })
   })

--- a/test/test-cid.spec.js
+++ b/test/test-cid.spec.js
@@ -708,4 +708,32 @@ describe('CID', () => {
     sender.close()
     receiver.close()
   })
+
+  describe('decode', () => {
+    const tests = {
+      v0: 'QmTFHZL5CkgNz19MdPnSuyLAi6AVq9fFp81zmPpaL2amED',
+      v1: 'bafybeif2pall7dybz7vecqka3zo24irdwabwdi4wc55jznaq75q7eaavvu'
+    }
+
+    Object.entries(tests).forEach(([version, cidString]) => {
+      it(`decode ${version} from bytes`, () => {
+        const cid1 = CID.parse(cidString)
+        const cid2 = CID.decode(cid1.bytes)
+
+        assert.deepStrictEqual(cid1, cid2)
+      })
+
+      it(`decode ${version} from subarray`, () => {
+        const cid1 = CID.parse(cidString)
+        // a byte array with an extra byte at the start and end
+        const bytes = new Uint8Array(cid1.bytes.length + 2)
+        bytes.set(cid1.bytes, 1)
+        // slice the cid bytes out of the middle to have a subarray with a non-zero .byteOffset
+        const subarray = bytes.subarray(1, cid1.bytes.length + 1)
+        const cid2 = CID.decode(subarray)
+
+        assert.deepStrictEqual(cid1, cid2)
+      })
+    })
+  })
 })


### PR DESCRIPTION
Fixes #208 by converting `.byteOffset` and `.byteLength` properties to getters.

Supersedes #210