### PR TITLE
Fix equality check

### DIFF
--- a/src/cid.js
+++ b/src/cid.js
@@ -78,15 +78,17 @@ export class CID {
     /** @readonly */
     this.bytes = bytes
 
-    // ArrayBufferView
-    /** @readonly */
-    this.byteOffset = bytes.byteOffset
-    /** @readonly */
-    this.byteLength = bytes.byteLength
-
     // Circular reference
     /** @readonly */
     this.asCID = this
+  }
+
+  get byteOffset () {
+    return this.bytes.byteOffset
+  }
+
+  get byteLength () {
+    return this.bytes.byteLength
   }
 
   /**
@@ -272,6 +274,10 @@ export class CID {
   static create (version, code, digest) {
     if (typeof code !== 'number') {
       throw new Error('String codecs are no longer supported')
+    }
+
+    if (!(digest.bytes instanceof Uint8Array)) {
+      throw new Error('Invalid multihash digest was passed')
     }
 
     switch (version) {

--- a/test/test-link.spec.js
+++ b/test/test-link.spec.js
@@ -124,6 +124,8 @@ describe('equality', () => {
 
     const actual = Link.decode(bytes)
     assert.equal(expect.toString(), actual.toString())
+    assert.equal(expect.byteLength, actual.byteLength)
+    assert.notEqual(expect.byteOffset, actual.byteOffset)
 
     assert.deepEqual(expect, actual)
   })

--- a/test/test-link.spec.js
+++ b/test/test-link.spec.js
@@ -114,3 +114,17 @@ describe('decode', () => {
     assert.deepStrictEqual(multihash, hash)
   })
 })
+
+describe('equality', () => {
+  it('passes equality check despite diff offsets', () => {
+    const expect = Link.parse('QmRnTwp7crEvYEdyWhW7FGQ3thWMvgTATcbUs1uyHVuSNq')
+    const buffer = new ArrayBuffer(256)
+    const bytes = new Uint8Array(buffer, 12, expect.bytes.byteLength)
+    bytes.set(expect.bytes)
+
+    const actual = Link.decode(bytes)
+    assert.equal(expect.toString(), actual.toString())
+
+    assert.deepEqual(expect, actual)
+  })
+})


### PR DESCRIPTION
Fixes #208

I've looked into the issue and turns out it can only occur on CIDv0, because CIDv1 always seem to re-encode (which I think is a bug btw)

https://github.com/multiformats/js-multiformats/blob/0ec751a62eb96f2609916b061ac5e64a83ee1de9/src/cid.js#L381
https://github.com/multiformats/js-multiformats/blob/0ec751a62eb96f2609916b061ac5e64a83ee1de9/src/cid.js#L287-L289



Never the less this turns `byteOffset` and `byteLength` to getters so they won't be considered in equality checks.


I also had to add check `digest.bytes instance Uint8Array` check otherwise some tests passing garbage data were no longer throwing on construction.