### PR TITLE
fix: use slash as flag that an object is a CID

### DIFF
--- a/src/cid.js
+++ b/src/cid.js
@@ -84,6 +84,16 @@ export class CID {
     this['/'] = bytes
   }
 
+  /**
+   * Signalling `cid.asCID === cid` has been replaced with `cid['/'] === cid.bytes`
+   * please either use `CID.asCID(cid)` or switch to new signalling mechanism
+   *
+   * @deprecated
+   */
+  get asCID () {
+    return this
+  }
+
   // ArrayBufferView
   get byteOffset () {
     return this.bytes.byteOffset
@@ -249,7 +259,7 @@ export class CID {
         version,
         code,
         /** @type {API.MultihashDigest<Alg>} */ (multihash),
-        value['/'] ?? bytes ?? encodeCID(version, code, multihash.bytes)
+        bytes || encodeCID(version, code, multihash.bytes)
       )
     } else if (value[cidSymbol] === true) {
       // If value is a CID from older implementation that used to be tagged via

--- a/src/link.js
+++ b/src/link.js
@@ -36,8 +36,25 @@ export const create = (code, digest) => CID.create(1, code, digest)
  * @param {unknown|L} value
  * @returns {value is L & CID}
  */
-export const isLink = value =>
-  value != null && /** @type {{asCID: unknown}} */ (value).asCID === value
+export const isLink = value => {
+  if (value == null) {
+    return false
+  }
+
+  const withSlash = /** @type {{'/'?: Uint8Array, bytes: Uint8Array}} */ (value)
+
+  if (withSlash['/'] != null && withSlash['/'] === withSlash.bytes) {
+    return true
+  }
+
+  const withAsCID = /** @type {{'asCID'?: unknown}} */ (value)
+
+  if (withAsCID.asCID === value) {
+    return true
+  }
+
+  return false
+}
 
 /**
  * Takes cid in a string representation and creates an instance. If `base`

--- a/test/test-cid.spec.js
+++ b/test/test-cid.spec.js
@@ -704,9 +704,9 @@ describe('CID', () => {
     const cid2 = await new Promise((resolve) => {
       receiver.onmessage = (event) => { resolve(event.data) }
     })
-    assert.strictEqual(cid2['/'], cid2.bytes)
     sender.close()
     receiver.close()
+    assert.strictEqual(cid2['/'], cid2.bytes)
   })
 
   describe('decode', () => {

--- a/test/test-cid.spec.js
+++ b/test/test-cid.spec.js
@@ -704,7 +704,7 @@ describe('CID', () => {
     const cid2 = await new Promise((resolve) => {
       receiver.onmessage = (event) => { resolve(event.data) }
     })
-    assert.strictEqual(cid2.asCID, cid2)
+    assert.strictEqual(cid2['/'], cid2.bytes)
     sender.close()
     receiver.close()
   })


### PR DESCRIPTION
As per https://github.com/multiformats/js-multiformats/issues/212 making `asCID` enumerable breaks tests where modules don't handle self-referential data properly.

As proposed in https://github.com/multiformats/js-multiformats/issues/213 this swaps `cid.CID === cid` for `cid['/'] === cid.bytes` as a mechanism to tell consumers that the object in question is a `CID` which lets them write CBOR with the correct tags, for example.

Fixes #212
Closes #213