### PR TITLE
chore: remove unnecessary dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -262,14 +262,9 @@
   "devDependencies": {
     "@stablelib/sha256": "^1.0.1",
     "@stablelib/sha512": "^1.0.1",
-    "@types/chai": "^4.3.0",
-    "@types/chai-as-promised": "^7.1.4",
-    "@types/mocha": "^10.0.0",
     "@types/node": "^18.0.0",
     "aegir": "^37.5.1",
     "buffer": "^6.0.3",
-    "chai": "^4.3.4",
-    "chai-as-promised": "^7.1.1",
     "cids": "^1.1.9"
   },
   "aegir": {

--- a/test/test-block.spec.js
+++ b/test/test-block.spec.js
@@ -3,11 +3,7 @@ import * as codec from '../src/codecs/json.js'
 import { sha256 as hasher } from '../src/hashes/sha2.js'
 import * as main from '../src/block.js'
 import { CID, bytes } from '../src/index.js'
-import chai from 'chai'
-import chaiAsPromised from 'chai-as-promised'
-
-chai.use(chaiAsPromised)
-const { assert } = chai
+import { assert } from 'aegir/chai'
 
 const fixture = { hello: 'world' }
 const link = CID.parse('bafyreidykglsfhoixmivffc5uwhcgshx4j465xwqntbmu43nb2dzqwfvae')

--- a/test/test-bytes.spec.js
+++ b/test/test-bytes.spec.js
@@ -1,6 +1,6 @@
 /* globals describe, it */
 import * as bytes from '../src/bytes.js'
-import { assert } from 'chai'
+import { assert } from 'aegir/chai'
 
 describe('bytes', () => {
   it('isBinary', () => {

--- a/test/test-cid.spec.js
+++ b/test/test-cid.spec.js
@@ -8,14 +8,10 @@ import { base64 } from '../src/bases/base64.js'
 import { sha256, sha512 } from '../src/hashes/sha2.js'
 import invalidMultihash from './fixtures/invalid-multihash.js'
 import OLDCID from 'cids'
-import chai from 'chai'
-import chaiAsPromised from 'chai-as-promised'
+import { assert } from 'aegir/chai'
 // Linter can see that API is used in types.
 // eslint-disable-next-line
 import * as API from 'multiformats'
-
-chai.use(chaiAsPromised)
-const { assert } = chai
 
 const textEncoder = new TextEncoder()
 

--- a/test/test-link.spec.js
+++ b/test/test-link.spec.js
@@ -1,12 +1,9 @@
 /* globals describe, it */
 
 import * as Link from '../src/link.js'
-import chai from 'chai'
-import chaiAsPromised from 'chai-as-promised'
+import { assert } from 'aegir/chai'
 import { sha256 } from '../src/hashes/sha2.js'
 
-chai.use(chaiAsPromised)
-const { assert } = chai
 const utf8 = new TextEncoder()
 
 const h1 = 'QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n'

--- a/test/test-multibase-spec.spec.js
+++ b/test/test-multibase-spec.spec.js
@@ -2,11 +2,7 @@
 
 import { bases } from '../src/basics.js'
 import { fromString } from '../src/bytes.js'
-import chai from 'chai'
-import chaiAsPromised from 'chai-as-promised'
-
-chai.use(chaiAsPromised)
-const { assert } = chai
+import { assert } from 'aegir/chai'
 
 const encoded = [
   {

--- a/test/test-multibase.spec.js
+++ b/test/test-multibase.spec.js
@@ -8,11 +8,7 @@ import * as b32 from '../src/bases/base32.js'
 import * as b36 from '../src/bases/base36.js'
 import * as b58 from '../src/bases/base58.js'
 import * as b64 from '../src/bases/base64.js'
-import chai from 'chai'
-import chaiAsPromised from 'chai-as-promised'
-
-chai.use(chaiAsPromised)
-const { assert } = chai
+import { assert } from 'aegir/chai'
 
 const { base16, base32, base58btc, base64 } = { ...b16, ...b32, ...b58, ...b64 }
 

--- a/test/test-multicodec.spec.js
+++ b/test/test-multicodec.spec.js
@@ -2,11 +2,7 @@
 import * as bytes from '../src/bytes.js'
 import * as raw from '../src/codecs/raw.js'
 import * as json from '../src/codecs/json.js'
-import chai from 'chai'
-import chaiAsPromised from 'chai-as-promised'
-
-chai.use(chaiAsPromised)
-const { assert } = chai
+import { assert } from 'aegir/chai'
 
 describe('multicodec', () => {
   it('encode/decode raw', () => {

--- a/test/test-multihash.spec.js
+++ b/test/test-multihash.spec.js
@@ -7,11 +7,7 @@ import valid from './fixtures/valid-multihash.js'
 import invalid from './fixtures/invalid-multihash.js'
 import { hash as slSha256 } from '@stablelib/sha256'
 import { hash as slSha512 } from '@stablelib/sha512'
-import chai from 'chai'
-import chaiAsPromised from 'chai-as-promised'
-
-chai.use(chaiAsPromised)
-const { assert } = chai
+import { assert } from 'aegir/chai'
 
 /**
  * @param {number|string} code

--- a/test/test-traversal.spec.js
+++ b/test/test-traversal.spec.js
@@ -4,7 +4,7 @@ import { sha256 as hasher } from '../src/hashes/sha2.js'
 import * as main from '../src/block.js'
 import { walk } from '../src/traversal.js'
 import { fromString } from '../src/bytes.js'
-import { assert } from 'chai'
+import { assert } from 'aegir/chai'
 
 /** @typedef {import('../src/cid.js').CID} CID */
 


### PR DESCRIPTION
Aegir has `chai` preconfigured with the relevant plugins so use that instead of declaring additional dependencies for slighter faster install times.