### PR TITLE
fix: list links of a block that _is a_ CID

### DIFF
--- a/package.json
+++ b/package.json
@@ -250,7 +250,7 @@
     "lint": "aegir lint",
     "build": "aegir build",
     "release": "aegir release",
-    "test": "npm run lint && npm run test:node && npm run test:chrome && npm run test:ts",
+    "test": "npm run test:node && npm run test:chrome && npm run test:ts",
     "test:ts": "npm run test --prefix test/ts-use",
     "test:node": "aegir test -t node --cov",
     "test:chrome": "aegir test -t browser --cov",

--- a/package.json
+++ b/package.json
@@ -250,7 +250,7 @@
     "lint": "aegir lint",
     "build": "aegir build",
     "release": "aegir release",
-    "test": "npm run test:node && npm run test:chrome && npm run test:ts",
+    "test": "npm run lint && npm run test:node && npm run test:chrome && npm run test:ts",
     "test:ts": "npm run test --prefix test/ts-use",
     "test:node": "aegir test -t node --cov",
     "test:chrome": "aegir test -t browser --cov",

--- a/src/block.js
+++ b/src/block.js
@@ -45,6 +45,10 @@ function * links (source, base) {
   if (source == null || source instanceof Uint8Array) {
     return
   }
+  const cid = CID.asCID(source)
+  if (cid) {
+    yield [base.join('/'), cid]
+  }
   for (const [key, value] of Object.entries(source)) {
     const path = /** @type {[string|number, string]} */ ([...base, key])
     yield * linksWithin(path, value)

--- a/test/test-block.spec.js
+++ b/test/test-block.spec.js
@@ -83,6 +83,17 @@ describe('block', () => {
     })
   })
 
+  it('links of a block that is a CID', async () => {
+    const block = await main.encode({ value: link, codec, hasher })
+    const links = []
+    for (const link of block.links()) {
+      links.push(link)
+    }
+    assert.equal(links.length, 1)
+    assert.equal(links[0][0], '')
+    assert.equal(links[0][1].toString(), link.toString())
+  })
+
   it('kitchen sink', () => {
     const sink = { one: { two: { arr: [true, false, null], three: 3, buff, link } } }
     const block = main.createUnsafe({


### PR DESCRIPTION
If a block _**is a**_ CID, it is not listed by the block `.links()` method. This PR fixes that.

For example, this is a block that is a CID:

```console
$ echo '{ "/": "bafyreihlhgo2srya7ihdyc5ae76rki47irecf4thjfjhsmrjyeurlyhbua" }' | ipfs dag put
bafyreiexxrljy6el4v7phukkux3ukhzuiuajsilzd63576oysy3vhll3ia
```

P.S. I also removed the `npm run lint` command from the `test` script since the `no-only-tests` rule was in the way of me being able to test my work. It is run in CI already. I can revert if anyone feels strongly in the opposite direction.

---

As an aside:

It looks like there's not really a way to _path_ through these kind of blocks, at least not with go/js ipfs.

For example, here's a tree with `node => CID node => node`:

```console
$ echo '{ "bar": "Hello World!" }' | ipfs dag put
bafyreihlhgo2srya7ihdyc5ae76rki47irecf4thjfjhsmrjyeurlyhbua

$ echo '{ "/": "bafyreihlhgo2srya7ihdyc5ae76rki47irecf4thjfjhsmrjyeurlyhbua" }' | ipfs dag put
bafyreiexxrljy6el4v7phukkux3ukhzuiuajsilzd63576oysy3vhll3ia

$ echo '{ "foo": { "/": "bafyreiexxrljy6el4v7phukkux3ukhzuiuajsilzd63576oysy3vhll3ia" } }' | ipfs dag put
bafyreidb7fynlo5246wst4tyl3wucfoskujuuq4523srgc73c6xlvnah2i
```

You cannot path to "Hello World!" from `bafyreidb7fynlo5246wst4tyl3wucfoskujuuq4523srgc73c6xlvnah2i`:

```console
$ ipfs dag get bafyreidb7fynlo5246wst4tyl3wucfoskujuuq4523srgc73c6xlvnah2i/foo
{"/":"bafyreihlhgo2srya7ihdyc5ae76rki47irecf4thjfjhsmrjyeurlyhbua"}

$ ipfs dag get bafyreidb7fynlo5246wst4tyl3wucfoskujuuq4523srgc73c6xlvnah2i/foo/bar
Error: func called on wrong kind: "LookupBySegment" called on a link node (kind: link), but only makes sense on map or list

$ ipfs dag get bafyreidb7fynlo5246wst4tyl3wucfoskujuuq4523srgc73c6xlvnah2i/foo//bar
Error: func called on wrong kind: "LookupBySegment" called on a link node (kind: link), but only makes sense on map or list
```

Similarly in js-ipfs:

```console
$ ipfs dag get bafyreidb7fynlo5246wst4tyl3wucfoskujuuq4523srgc73c6xlvnah2i/foo/bar
dag get failed: Error: no link named "bar" under bafyreiexxrljy6el4v7phukkux3ukhzuiuajsilzd63576oysy3vhll3ia
```

refs https://github.com/ipld/ipld/issues/250