### PR TITLE
feat!: Make link.toJSON return a DAG-JSON link

### DIFF
--- a/src/cid.js
+++ b/src/cid.js
@@ -35,6 +35,22 @@ export const format = (link, base) => {
   }
 }
 
+/**
+ * @template {API.UnknownLink} Link
+ * @param {Link} link
+ * @returns {API.LinkJSON<Link>}
+ */
+export const toJSON = (link) => ({
+  '/': format(link)
+})
+
+/**
+ * @template {API.UnknownLink} Link
+ * @param {API.LinkJSON<Link>} json
+ */
+export const fromJSON = (json) =>
+  CID.parse(json['/'])
+
 /** @type {WeakMap<API.UnknownLink, Map<string, string>>} */
 const cache = new WeakMap()
 
@@ -200,11 +216,7 @@ export class CID {
   }
 
   toJSON () {
-    return {
-      code: this.code,
-      version: this.version,
-      hash: this.multihash.bytes
-    }
+    return { '/': format(this) }
   }
 
   link () {

--- a/src/link.js
+++ b/src/link.js
@@ -1,7 +1,7 @@
 // Linter can see that API is used in types.
 // eslint-disable-next-line
 import * as API from "./link/interface.js"
-import { CID, format } from './cid.js'
+import { CID, format, toJSON, fromJSON } from './cid.js'
 // This way TS will also expose all the types from module
 export * from './link/interface.js'
 
@@ -73,7 +73,7 @@ export const isLink = value => {
  */
 export const parse = (source, base) => CID.parse(source, base)
 
-export { format }
+export { format, toJSON, fromJSON }
 
 /**
  * Decoded a CID from its binary representation. The byte array must contain

--- a/src/link/interface.ts
+++ b/src/link/interface.ts
@@ -35,10 +35,13 @@ export interface Link<
   equals: (other: unknown) => other is Link<Data, Format, Alg, Version>
 
   toString: <Prefix extends string>(base?: MultibaseEncoder<Prefix>) => ToString<Link<Data, Format, Alg, Version>, Prefix>
-  toJSON: () => { version: V, code: Format, hash: Uint8Array }
   link: () => Link<Data, Format, Alg, V>
 
   toV1: () => Link<Data, Format, Alg, 1>
+}
+
+export interface LinkJSON<T extends UnknownLink = UnknownLink> {
+  '/': ToString<T>
 }
 
 export interface LegacyLink<T extends unknown = unknown> extends Link<T, DAG_PB, SHA_256, 0> {

--- a/test/test-cid.spec.js
+++ b/test/test-cid.spec.js
@@ -482,13 +482,10 @@ describe('CID', () => {
   it('toJSON()', async () => {
     const hash = await sha256.digest(textEncoder.encode('abc'))
     const cid = CID.create(1, 112, hash)
-    const json = cid.toJSON()
 
-    assert.deepStrictEqual(
-      { ...json, hash: null },
-      { code: 112, version: 1, hash: null }
-    )
-    assert.ok(equals(json.hash, hash.bytes))
+    assert.deepStrictEqual(cid.toJSON(), {
+      '/': cid.toString()
+    })
   })
 
   it('asCID', async () => {

--- a/test/test-link.spec.js
+++ b/test/test-link.spec.js
@@ -89,6 +89,42 @@ describe('Link', () => {
       assert.ok(t2)
     })
   })
+
+  describe('toJSON', () => {
+    assert.deepStrictEqual(Link.toJSON(Link.parse(h1)), {
+      '/': h1
+    })
+
+    assert.deepStrictEqual(Link.toJSON(Link.parse(h4)), {
+      '/': h4
+    })
+  })
+
+  describe('fromJSON', () => {
+    assert.deepStrictEqual(Link.parse(h1), Link.fromJSON({
+      '/': h1
+    }))
+
+    assert.deepStrictEqual(Link.parse(h1), Link.fromJSON({
+      '/': h1,
+      // @ts-expect-error
+      foo: 1
+    }))
+
+    assert.deepStrictEqual(Link.parse(h4), Link.fromJSON({
+      '/': h4
+    }))
+  })
+
+  describe('JSON.stringify', () => {
+    assert.equal(JSON.stringify(Link.parse(h1)), JSON.stringify({
+      '/': h1
+    }))
+
+    assert.equal(JSON.stringify(Link.parse(h4)), JSON.stringify({
+      '/': h4
+    }))
+  })
 })
 
 describe('decode', () => {


### PR DESCRIPTION
Changes toJSON implementation of the CID so it returns [Link in DAG-JSON format](https://ipld.io/specs/codecs/dag-json/spec/#links) as opposed to object with Uint8Array which gets munged with `JSON.stringify`

Fixes #228 