### PR TITLE
docs: publish typedocs in gh-pages branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ types
 test/ts-use/tsconfig.tsbuildinfo
 types/tsconfig.tsbuildinfo
 *.log
+dist
+.docs

--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
 
 [![multiformats.io](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](http://multiformats.io)
 [![codecov](https://img.shields.io/codecov/c/github/multiformats/js-multiformats.svg?style=flat-square)](https://codecov.io/gh/multiformats/js-multiformats)
-[![CI](https://img.shields.io/github/workflow/status/multiformats/js-multiformats/test%20&%20maybe%20release/esm-migration?style=flat-square)](https://github.com/multiformats/js-multiformats/actions/workflows/js-test-and-release.yml)
+[![CI](https://img.shields.io/github/workflow/status/multiformats/js-multiformats/test%20&%20maybe%20release/master?style=flat-square)](https://github.com/multiformats/js-multiformats/actions/workflows/js-test-and-release.yml)
 
 > Interface for multihash, multicodec, multibase and CID
 
 ## Table of contents <!-- omit in toc -->
 
 - [Install](#install)
+  - [Browser `<script>` tag](#browser-script-tag)
 - [Interfaces](#interfaces)
   - [Creating Blocks](#creating-blocks)
   - [Multibase Encoders / Decoders / Codecs](#multibase-encoders--decoders--codecs)
@@ -20,6 +21,7 @@
   - [Multibase codecs](#multibase-codecs)
   - [Multihash hashers](#multihash-hashers-1)
   - [IPLD codecs (multicodec)](#ipld-codecs-multicodec)
+- [API Docs](#api-docs)
 - [License](#license)
 - [Contribution](#contribution)
 
@@ -27,6 +29,14 @@
 
 ```console
 $ npm i multiformats
+```
+
+### Browser `<script>` tag
+
+Loading this module through a script tag will make it's exports available as `Multiformats` in the global namespace.
+
+```html
+<script src="https://unpkg.com/multiformats/dist/index.min.js"></script>
 ```
 
 ## Interfaces
@@ -232,6 +242,10 @@ Other (less useful) bases implemented in [multiformats/js-multiformats](https://
 | `dag-json` | `@ipld/dag-json`           | [ipld/js-dag-json](https://github.com/ipld/js-dag-json)                                                |
 | `dag-pb`   | `@ipld/dag-pb`             | [ipld/js-dag-pb](https://github.com/ipld/js-dag-pb)                                                    |
 | `dag-jose` | `dag-jose`                 | [ceramicnetwork/js-dag-jose](https://github.com/ceramicnetwork/js-dag-jose)                            |
+
+## API Docs
+
+- <https://multiformats.github.io/js-multiformats>
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![multiformats.io](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](http://multiformats.io)
 [![codecov](https://img.shields.io/codecov/c/github/multiformats/js-multiformats.svg?style=flat-square)](https://codecov.io/gh/multiformats/js-multiformats)
-[![CI](https://img.shields.io/github/workflow/status/multiformats/js-multiformats/test%20&%20maybe%20release/master?style=flat-square)](https://github.com/multiformats/js-multiformats/actions/workflows/js-test-and-release.yml)
+[![CI](https://img.shields.io/github/actions/workflow/status/multiformats/js-multiformats/js-test-and-release.yml?branch=master\&style=flat-square)](https://github.com/multiformats/js-multiformats/actions/workflows/js-test-and-release.yml?query=branch%3Amaster)
 
 > Interface for multihash, multicodec, multibase and CID
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "src",
     "test",
     "tsconfig.json",
-    "dist/types",
+    "dist",
     "vendor",
     "!**/*.tsbuildinfo",
     "!test/ts-use/node_modules"
@@ -250,6 +250,7 @@
     "lint": "aegir lint",
     "build": "aegir build",
     "release": "aegir release",
+    "docs": "aegir docs",
     "test": "npm run lint && npm run test:node && npm run test:chrome && npm run test:ts",
     "test:ts": "npm run test --prefix test/ts-use",
     "test:node": "aegir test -t node --cov",
@@ -263,7 +264,7 @@
     "@stablelib/sha256": "^1.0.1",
     "@stablelib/sha512": "^1.0.1",
     "@types/node": "^18.0.0",
-    "aegir": "^37.5.1",
+    "aegir": "^37.7.5",
     "buffer": "^6.0.3",
     "cids": "^1.1.9"
   },


### PR DESCRIPTION
Updates aegir to the latest version which has reinstated the `docs` command to publish typedocs in the `gh-pages` branch of repos.

A `typedoc-urls.json` file is now generated as part of the docs run which allows cross-linking between module docs.

This file lives at the "well known" location of `dist/typedoc-urls.json` in the published tarball, so the `files` list in `package.json` needed changing as it's currently only publishing `dist/types`.

See https://multiformats.github.io/js-multiaddr for an example.