### PR TITLE
fix: build browser bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -269,9 +269,6 @@
     "cids": "^1.1.9"
   },
   "aegir": {
-    "build": {
-      "bundle": false
-    },
     "test": {
       "target": [
         "node",


### PR DESCRIPTION
Enable shipping a minified browser bundle.

Fixes #234