### PR TITLE
docs: fix typos in jsdoc comments

### DIFF
--- a/src/block/interface.ts
+++ b/src/block/interface.ts
@@ -10,7 +10,7 @@ import { CID } from '../cid.js'
  * a `Data` type parameter indicating the type of encoded data.
  *
  * For example, a `ByteView<{ hello: "world" }>` is a `Uint8Array` containing a
- * binary representation of a `{hello: "world"}.
+ * binary representation of a `{hello: "world"}`.
  */
 export interface ByteView<Data> extends Uint8Array, Phantom<Data> {}
 
@@ -22,16 +22,16 @@ declare const Marker: unique symbol
  *
  * Capturing unused type parameters allows us to define "nominal types," which
  * TypeScript does not natively support. Nominal types in turn allow us to capture
- * semantics not represented in the actual type structure, without requring us to define
+ * semantics not represented in the actual type structure, without requiring us to define
  * new classes or pay additional runtime costs.
  *
  * For a concrete example, see {@link ByteView}, which extends the `Uint8Array` type to capture
  * type information about the structure of the data encoded into the array.
  */
 export interface Phantom<T> {
-  // This field can not be represented because field name is nonexistent
+  // This field can not be represented because field name is non-existent
   // unique symbol. But given that field is optional any object will valid
-  // type contstraint.
+  // type constraint.
   [Marker]?: T
 }
 

--- a/src/cid.js
+++ b/src/cid.js
@@ -226,7 +226,7 @@ export class CID {
    * a `CID` otherwise returns `null`. If `value` is instanceof `CID`
    * it will return value back. If `value` is not instance of this CID
    * class, but is compatible CID it will return new instance of this
-   * `CID` class. Otherwise returs null.
+   * `CID` class. Otherwise returns null.
    *
    * This allows two different incompatible versions of CID library to
    * co-exist and interop as long as binary interface is compatible.

--- a/src/hashes/digest.js
+++ b/src/hashes/digest.js
@@ -66,7 +66,7 @@ export const equals = (a, b) => {
 
 /**
  * Represents a multihash digest which carries information about the
- * hashing alogrithm and an actual hash digest.
+ * hashing algorithm and an actual hash digest.
  *
  * @template {number} Code
  * @template {number} Size


### PR DESCRIPTION
Fixes typos in comments used for generated documentation