### PR TITLE
fix: update link interface path in exports map

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,8 +167,8 @@
       "import": "./src/link.js"
     },
     "./link/interface": {
-      "types": "./dist/types/src/interface.d.ts",
-      "import": "./src/interface.js"
+      "types": "./dist/types/src/link/interface.d.ts",
+      "import": "./src/link/interface.js"
     },
     "./traversal": {
       "types": "./dist/types/src/traversal.d.ts",


### PR DESCRIPTION
The types and import fields were pointing to the wrong files so correct them.