### PR TITLE
docs: Update README about ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,6 @@ Maintainers are in [CODEOWNERS](./CODEOWNERS).
 
 Following [the decision](https://github.com/multiformats/js-multiformats/issues/273) to expand ownership to js-libp2p and helia maintainers, issues and PRs are now triaged and handled as part of the multi-party [js-libp2p Open Maintainers Call](https://lu.ma/js-libp2p)
 
-The most recent ownership conversation happened in [#273](https://github.com/multiformats/js-multiformats/issues/273).
 
 ## License
 


### PR DESCRIPTION
Make a note about who the owners/maintainers are and where they gather. 

This helps fix https://github.com/multiformats/js-multiformats/issues/273

This should be merged after:
- [ ] https://github.com/multiformats/github-mgmt/pull/83
- [x] https://github.com/libp2p/js-libp2p/pull/2082