### PR TITLE
feat: BlockEncoder#encode and BlockDecoder#decode can be async

### DIFF
--- a/src/block.js
+++ b/src/block.js
@@ -178,7 +178,7 @@ async function encode ({ value, codec, hasher }) {
   if (typeof value === 'undefined') throw new Error('Missing required argument "value"')
   if (!codec || !hasher) throw new Error('Missing required argument: codec or hasher')
 
-  const bytes = codec.encode(value)
+  const bytes = await codec.encode(value)
   const hash = await hasher.digest(bytes)
   /** @type {CID<T, Code, Alg, 1>} */
   const cid = CID.create(

--- a/src/block.js
+++ b/src/block.js
@@ -204,7 +204,7 @@ async function decode ({ bytes, codec, hasher }) {
   if (!bytes) throw new Error('Missing required argument "bytes"')
   if (!codec || !hasher) throw new Error('Missing required argument: codec or hasher')
 
-  const value = codec.decode(bytes)
+  const value = await codec.decode(bytes)
   const hash = await hasher.digest(bytes)
   /** @type {CID<T, Code, Alg, 1>} */
   const cid = CID.create(1, codec.code, hash)
@@ -223,12 +223,12 @@ async function decode ({ bytes, codec, hasher }) {
  * @template {number} Alg - multicodec code corresponding to the hashing algorithm used in CID creation.
  * @template {API.Version} V - CID version
  * @param {{ cid: API.Link<T, Code, Alg, V>, value:T, codec?: API.BlockDecoder<Code, T>, bytes: API.ByteView<T> }|{cid:API.Link<T, Code, Alg, V>, bytes:API.ByteView<T>, value?:void, codec:API.BlockDecoder<Code, T>}} options
- * @returns {API.BlockView<T, Code, Alg, V>}
+ * @returns {Promise<API.BlockView<T, Code, Alg, V>>}
  */
-function createUnsafe ({ bytes, cid, value: maybeValue, codec }) {
+async function createUnsafe ({ bytes, cid, value: maybeValue, codec }) {
   const value = maybeValue !== undefined
     ? maybeValue
-    : (codec && codec.decode(bytes))
+    : (codec && await codec.decode(bytes))
 
   if (value === undefined) throw new Error('Missing required argument, must either provide "value" or "codec"')
 
@@ -255,7 +255,7 @@ function createUnsafe ({ bytes, cid, value: maybeValue, codec }) {
 async function create ({ bytes, cid, hasher, codec }) {
   if (!bytes) throw new Error('Missing required argument "bytes"')
   if (!hasher) throw new Error('Missing required argument "hasher"')
-  const value = codec.decode(bytes)
+  const value = await codec.decode(bytes)
   const hash = await hasher.digest(bytes)
   if (!binary.equals(cid.multihash.bytes, hash.bytes)) {
     throw new Error('CID hash does not match bytes')

--- a/src/codecs/interface.ts
+++ b/src/codecs/interface.ts
@@ -14,7 +14,7 @@ export interface BlockEncoder<Code extends number, T> {
  */
 export interface BlockDecoder<Code extends number, T> {
   code: Code
-  decode(bytes: ByteView<T>): T
+  decode(bytes: ByteView<T>): T | Promise<T>
 }
 
 /**

--- a/src/codecs/interface.ts
+++ b/src/codecs/interface.ts
@@ -6,7 +6,7 @@ import type { ByteView } from '../block/interface.js'
 export interface BlockEncoder<Code extends number, T> {
   name: string
   code: Code
-  encode(data: T): ByteView<T>
+  encode(data: T): ByteView<T> | Promise<ByteView<T>>
 }
 
 /**

--- a/test/test-block.spec.js
+++ b/test/test-block.spec.js
@@ -23,11 +23,11 @@ describe('block', () => {
 
   it('createUnsafe', async () => {
     const block = await main.encode({ value: fixture, codec, hasher })
-    const block2 = main.createUnsafe({ bytes: block.bytes, cid: block.cid, codec })
+    const block2 = await main.createUnsafe({ bytes: block.bytes, cid: block.cid, codec })
     assert.deepStrictEqual(block.cid.equals(block2.cid), true)
   })
 
-  describe('reader', () => {
+  describe('reader', async () => {
     const value = {
       link,
       nope: 'skip',
@@ -37,7 +37,7 @@ describe('block', () => {
       bytes: Uint8Array.from('1234')
     }
     // @ts-expect-error - 'boolean' is not assignable to type 'CID'
-    const block = main.createUnsafe({ value, codec, hasher, cid: true, bytes: true })
+    const block = await main.createUnsafe({ value, codec, hasher, cid: true, bytes: true })
 
     it('links', () => {
       const expected = ['link', 'arr/0']
@@ -63,8 +63,8 @@ describe('block', () => {
       assert.deepStrictEqual(ret, { value: 'skip' })
     })
 
-    it('null links/tree', () => {
-      const block = main.createUnsafe({
+    it('null links/tree', async () => {
+      const block = await main.createUnsafe({
         value: null,
         codec,
         hasher,
@@ -95,9 +95,9 @@ describe('block', () => {
     assert.equal(links[0][1].toString(), link.toString())
   })
 
-  it('kitchen sink', () => {
+  it('kitchen sink', async () => {
     const sink = { one: { two: { arr: [true, false, null], three: 3, buff, link } } }
-    const block = main.createUnsafe({
+    const block = await main.createUnsafe({
       value: sink,
       codec,
       // @ts-expect-error - 'boolean' is not assignable to type 'ByteView<unknown>'
@@ -133,7 +133,7 @@ describe('block', () => {
 
     it('createUnsafe', async () => {
       // @ts-expect-error
-      assert.throws(() => main.createUnsafe({}), 'Missing required argument, must either provide "value" or "codec"')
+      assert.isRejected(main.createUnsafe({}), 'Missing required argument, must either provide "value" or "codec"')
     })
 
     it('create', async () => {


### PR DESCRIPTION
I want to be able to use async functions in my Block encode/decode.
