### PR TITLE
feat: add proquint multibase

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ import the ones you need yourself.
 | `base64`, `base64pad`, `base64url`, `base64urlpad`            | `multiformats/bases/base64` | [multiformats/js-multiformats](https://github.com/multiformats/js-multiformats/tree/master/bases) |
 | `base58btc`, `base58flick4`                                   | `multiformats/bases/base58` | [multiformats/js-multiformats](https://github.com/multiformats/js-multiformats/tree/master/bases) |
 
-Other (less useful) bases implemented in [multiformats/js-multiformats](https://github.com/multiformats/js-multiformats/tree/master/bases) include: `base2`, `base8`, `base10`, `base36` and `base256emoji`.
+Other (less useful) bases implemented in [multiformats/js-multiformats](https://github.com/multiformats/js-multiformats/tree/master/bases) include: `base2`, `base8`, `base10`, `base36`, `base45` and `base256emoji`.
 
 ### Multihash hashers
 

--- a/package.json
+++ b/package.json
@@ -90,6 +90,10 @@
       "types": "./dist/src/bases/identity.d.ts",
       "import": "./dist/src/bases/identity.js"
     },
+    "./bases/proquint": {
+      "types": "./dist/src/bases/proquint.d.ts",
+      "import": "./dist/src/bases/proquint.js"
+    },
     "./bases/interface": {
       "types": "./dist/src/bases/interface.d.ts",
       "import": "./dist/src/bases/interface.js"

--- a/package.json
+++ b/package.json
@@ -70,6 +70,10 @@
       "types": "./dist/src/bases/base36.d.ts",
       "import": "./dist/src/bases/base36.js"
     },
+    "./bases/base45": {
+      "types": "./dist/src/bases/base45.d.ts",
+      "import": "./dist/src/bases/base45.js"
+    },
     "./bases/base58": {
       "types": "./dist/src/bases/base58.d.ts",
       "import": "./dist/src/bases/base58.js"

--- a/src/bases/base45.ts
+++ b/src/bases/base45.ts
@@ -1,0 +1,51 @@
+import { from } from './base.js'
+
+const alphabet = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ $%*+-./:'
+
+function indexOf (char: string): number {
+  const index = alphabet.indexOf(char)
+  if (index === -1) {
+    throw new Error(`Non-base45 character: ${char}`)
+  }
+  return index
+}
+
+export const base45 = from({
+  name: 'base45',
+  prefix: 'R',
+  encode: (input: Uint8Array): string => {
+    let ret = ''
+    for (let i = 0; i < input.length; i += 2) {
+      if (i + 1 === input.length) {
+        const v = input[i]
+        const a = v / 45 | 0
+        const b = v % 45 | 0
+        ret += alphabet[b] + alphabet[a]
+        break
+      }
+      const v = input[i] << 8 | input[i + 1]
+      const a = v / 45 ** 2 | 0
+      const b = v / 45 % 45 | 0
+      const c = v % 45
+      ret += alphabet[c] + alphabet[b] + alphabet[a]
+    }
+    return ret
+  },
+  decode: (input: string): Uint8Array => {
+    if ((input.length * 2) % 3 === 2) {
+      throw new Error('Unexpected end of data')
+    }
+    const out = new Uint8Array(Math.floor(input.length * 2 / 3))
+    for (let i = 0; i < input.length; i += 3) {
+      if (i + 2 === input.length) {
+        const v = indexOf(input[i]) + indexOf(input[i + 1]) * 45
+        out[i / 3 * 2] = v
+        break
+      }
+      const v = indexOf(input[i]) + indexOf(input[i + 1]) * 45 + indexOf(input[i + 2]) * 45 ** 2
+      out[i / 3 * 2] = v >> 8
+      out[i / 3 * 2 + 1] = v & 0xff
+    }
+    return out
+  }
+})

--- a/src/bases/proquint.ts
+++ b/src/bases/proquint.ts
@@ -1,0 +1,87 @@
+import { from } from './base.js'
+
+const consonants = 'bdfghjklmnprstvz'
+const vowels = 'aiou'
+
+function consonantIndex (c: string): number {
+  const idx = consonants.indexOf(c)
+  if (idx === -1) {
+    throw new Error(`Non-proquint character: ${c}`)
+  }
+  return idx
+}
+
+function vowelIndex (v: string): number {
+  const idx = vowels.indexOf(v)
+  if (idx === -1) {
+    throw new Error(`Non-proquint character: ${v}`)
+  }
+  return idx
+}
+
+export const proquint = from({
+  name: 'proquint',
+  prefix: 'p',
+  encode: (input: Uint8Array): string => {
+    // blocks of 16 bits in the pattern:
+    // 4 bits = consonant
+    // 2 bits = vowel
+    // 4 bits = consonant
+    // 2 bits = vowel
+    // 4 bits = consonant
+    // '-'
+    let ret = 'ro-'
+    for (let i = 0; i < input.length; i += 2) {
+      let y = input[i] << 8
+      if (i + 1 !== input.length) {
+        y |= input[i + 1]
+      }
+      ret += consonants[y >> 12 & 0xf]
+      ret += vowels[(y >> 10) & 0x03]
+      ret += consonants[(y >> 6) & 0x0f]
+      if (i + 1 !== input.length) {
+        ret += vowels[(y >> 4) & 0x03]
+        ret += consonants[y & 0x0f]
+      }
+      if (i + 2 < input.length) {
+        ret += '-'
+      }
+    }
+
+    return ret
+  },
+  decode: (input: string): Uint8Array => {
+    if (!input.startsWith('ro-')) {
+      throw new Error('Invalid proquint string')
+    }
+    input = input.slice(3)
+    const out = []
+    let i = 0
+    while (i < input.length) {
+      const hasFive = input.length - i >= 5
+      // must have at least 3
+      if (!hasFive && input.length - i < 3) {
+        throw new Error('Unexpected end of data')
+      }
+      let y = consonantIndex(input[i++]) << 12
+      y |= vowelIndex(input[i++]) << 10
+      y |= consonantIndex(input[i++]) << 6
+      if (hasFive) {
+        y |= vowelIndex(input[i++]) << 4
+        y |= consonantIndex(input[i++])
+      }
+      out.push(y >> 8)
+      if (hasFive) {
+        out.push(y & 0xff)
+        if (input[i] === '-') {
+          if (i + 1 === input.length) {
+            throw new Error('Unexpected end of data')
+          }
+          i++
+        }
+      }
+    }
+
+    return Uint8Array.from(out)
+  }
+})

--- a/src/basics.ts
+++ b/src/basics.ts
@@ -9,13 +9,14 @@ import * as base58 from './bases/base58.js'
 import * as base64 from './bases/base64.js'
 import * as base8 from './bases/base8.js'
 import * as identityBase from './bases/identity.js'
+import * as proquint from './bases/proquint.js'
 import * as json from './codecs/json.js'
 import * as raw from './codecs/raw.js'
 import * as identity from './hashes/identity.js'
 import * as sha2 from './hashes/sha2.js'
 import { CID, hasher, digest, varint, bytes } from './index.js'
 
-export const bases = { ...identityBase, ...base2, ...base8, ...base10, ...base16, ...base32, ...base36, ...base45, ...base58, ...base64, ...base256emoji }
+export const bases = { ...identityBase, ...base2, ...base8, ...base10, ...base16, ...base32, ...base36, ...base45, ...base58, ...base64, ...base256emoji, ...proquint }
 export const hashes = { ...sha2, ...identity }
 export const codecs = { raw, json }
 

--- a/src/basics.ts
+++ b/src/basics.ts
@@ -4,6 +4,7 @@ import * as base2 from './bases/base2.js'
 import * as base256emoji from './bases/base256emoji.js'
 import * as base32 from './bases/base32.js'
 import * as base36 from './bases/base36.js'
+import * as base45 from './bases/base45.js'
 import * as base58 from './bases/base58.js'
 import * as base64 from './bases/base64.js'
 import * as base8 from './bases/base8.js'
@@ -14,7 +15,7 @@ import * as identity from './hashes/identity.js'
 import * as sha2 from './hashes/sha2.js'
 import { CID, hasher, digest, varint, bytes } from './index.js'
 
-export const bases = { ...identityBase, ...base2, ...base8, ...base10, ...base16, ...base32, ...base36, ...base58, ...base64, ...base256emoji }
+export const bases = { ...identityBase, ...base2, ...base8, ...base10, ...base16, ...base32, ...base36, ...base45, ...base58, ...base64, ...base256emoji }
 export const hashes = { ...sha2, ...identity }
 export const codecs = { raw, json }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -176,7 +176,7 @@
  * | `base64`, `base64pad`, `base64url`, `base64urlpad`            | `multiformats/bases/base64` | [multiformats/js-multiformats](https://github.com/multiformats/js-multiformats/tree/master/bases) |
  * | `base58btc`, `base58flick4`                                   | `multiformats/bases/base58` | [multiformats/js-multiformats](https://github.com/multiformats/js-multiformats/tree/master/bases) |
  *
- * Other (less useful) bases implemented in [multiformats/js-multiformats](https://github.com/multiformats/js-multiformats/tree/master/bases) include: `base2`, `base8`, `base10`, `base36` and `base256emoji`.
+ * Other (less useful) bases implemented in [multiformats/js-multiformats](https://github.com/multiformats/js-multiformats/tree/master/bases) include: `base2`, `base8`, `base10`, `base36`, `base45` and `base256emoji`.
  *
  * ### Multihash hashers
  *

--- a/test/test-multibase-spec.spec.ts
+++ b/test/test-multibase-spec.spec.ts
@@ -32,7 +32,8 @@ const encoded = [
       ['base64pad', 'MRGVjZW50cmFsaXplIGV2ZXJ5dGhpbmchIQ=='],
       ['base64url', 'uRGVjZW50cmFsaXplIGV2ZXJ5dGhpbmchIQ'],
       ['base64urlpad', 'URGVjZW50cmFsaXplIGV2ZXJ5dGhpbmchIQ=='],
-      ['base256emoji', '🚀💛✋💃✋😻😈🥺🤤🍀🌟💐✋😅✋💦✋🥺🏃😈😴🌟😻😝👏👏']
+      ['base256emoji', '🚀💛✋💃✋😻😈🥺🤤🍀🌟💐✋😅✋💦✋🥺🏃😈😴🌟😻😝👏👏'],
+      ['proquint', 'pro-hidoj-katoj-kunuh-lanod-kudon-lonoj-fadoj-linoj-lanun-lidom-kojov-kisod-fah']
     ]
   },
   {
@@ -62,7 +63,8 @@ const encoded = [
       ['base64pad', 'MeWVzIG1hbmkgIQ=='],
       ['base64url', 'ueWVzIG1hbmkgIQ'],
       ['base64urlpad', 'UeWVzIG1hbmkgIQ=='],
-      ['base256emoji', '🚀🏃✋🌈😅🌷🤤😻🌟😅👏']
+      ['base256emoji', '🚀🏃✋🌈😅🌷🤤😻🌟😅👏'],
+      ['proquint', 'pro-lojoj-lasob-kujod-kunon-fabod']
     ]
   },
   {
@@ -92,7 +94,8 @@ const encoded = [
       ['base64pad', 'MaGVsbG8gd29ybGQ='],
       ['base64url', 'uaGVsbG8gd29ybGQ'],
       ['base64urlpad', 'UaGVsbG8gd29ybGQ='],
-      ['base256emoji', '🚀😴✋🍀🍀😓😅✔😓🥺🍀😳']
+      ['base256emoji', '🚀😴✋🍀🍀😓😅✔😓🥺🍀😳'],
+      ['proquint', 'pro-kodoj-kudos-kusob-litoz-lanos-kib']
     ]
   },
   {
@@ -122,7 +125,8 @@ const encoded = [
       ['base64pad', 'MAHllcyBtYW5pICE='],
       ['base64url', 'uAHllcyBtYW5pICE'],
       ['base64urlpad', 'UAHllcyBtYW5pICE='],
-      ['base256emoji', '🚀🚀🏃✋🌈😅🌷🤤😻🌟😅👏']
+      ['base256emoji', '🚀🚀🏃✋🌈😅🌷🤤😻🌟😅👏'],
+      ['proquint', 'pro-badun-kijug-fadot-kajov-kohob-fah']
     ]
   },
   {
@@ -152,13 +156,30 @@ const encoded = [
       ['base64pad', 'MAAB5ZXMgbWFuaSAh'],
       ['base64url', 'uAAB5ZXMgbWFuaSAh'],
       ['base64urlpad', 'UAAB5ZXMgbWFuaSAh'],
-      ['base256emoji', '🚀🚀🚀🏃✋🌈😅🌷🤤😻🌟😅👏']
+      ['base256emoji', '🚀🚀🚀🏃✋🌈😅🌷🤤😻🌟😅👏'],
+      ['proquint', 'pro-babab-lojoj-lasob-kujod-kunon-fabod']
     ]
   },
+
+  // RFC9285 examples
   { input: 'AB', tests: [['base45', 'RBB8']] },
   { input: 'Hello!!', tests: [['base45', 'R%69 VD92EX0']] },
   { input: 'base-45', tests: [['base45', 'RUJCLQE7W581']] },
-  { input: 'ietf!', tests: [['base45', 'RQED8WEX0']] }
+  { input: 'ietf!', tests: [['base45', 'RQED8WEX0']] },
+
+  // proquint spec examples, IPv4 addresses
+  { input: Uint8Array.from([127, 0, 0, 1]), tests: [['proquint', 'pro-lusab-babad']] }, // 127.0.0.1
+  { input: Uint8Array.from([63, 84, 220, 193]), tests: [['proquint', 'pro-gutih-tugad']] }, // 63.84.220.193
+  { input: Uint8Array.from([63, 118, 7, 35]), tests: [['proquint', 'pro-gutuk-bisog']] }, // 63.118.7.35
+  { input: Uint8Array.from([140, 98, 193, 141]), tests: [['proquint', 'pro-mudof-sakat']] }, // 140.98.193.141
+  { input: Uint8Array.from([64, 255, 6, 200]), tests: [['proquint', 'pro-haguz-biram']] }, // 64.255.6.200
+  { input: Uint8Array.from([128, 30, 52, 45]), tests: [['proquint', 'pro-mabiv-gibot']] }, // 128.30.52.45
+  { input: Uint8Array.from([147, 67, 119, 2]), tests: [['proquint', 'pro-natag-lisaf']] }, // 147.67.119.2
+  { input: Uint8Array.from([212, 58, 253, 68]), tests: [['proquint', 'pro-tibup-zujah']] }, // 212.58.253.68
+  { input: Uint8Array.from([216, 35, 68, 215]), tests: [['proquint', 'pro-tobog-higil']] }, // 216.35.68.215
+  { input: Uint8Array.from([216, 68, 232, 21]), tests: [['proquint', 'pro-todah-vobij']] }, // 216.68.232.21
+  { input: Uint8Array.from([198, 81, 129, 136]), tests: [['proquint', 'pro-sinid-makam']] }, // 198.81.129.136
+  { input: Uint8Array.from([12, 110, 110, 204]), tests: [['proquint', 'pro-budov-kuras']] } // 12.110.110.204
 ]
 
 describe('spec test', () => {
@@ -169,13 +190,15 @@ describe('spec test', () => {
         const base = bases[name as keyof typeof bases]
 
         describe(name, () => {
+          const byteInput = typeof input === 'string' ? fromString(input) : input
+
           it(`should encode from buffer [${input}]`, () => {
-            const out = base.encode(fromString(input))
+            const out = base.encode(byteInput)
             assert.deepStrictEqual(out, output)
           })
 
           it(`should decode from string [${input}]`, () => {
-            assert.deepStrictEqual(base.decode(output), fromString(input))
+            assert.deepStrictEqual(base.decode(output), byteInput)
           })
         })
       }
@@ -187,6 +210,10 @@ describe('spec test', () => {
       if (base.name === 'identity') {
         return this.skip()
       }
+      if (base.name === 'proquint') {
+        assert.throws(() => base.decode('pro-^!@$%!#$%@#y'), `Non-${base.name} character`)
+        return
+      }
 
       assert.throws(() => base.decode(base.prefix + '^!@$%!#$%@#y'), `Non-${base.name} character`)
     })
@@ -195,5 +222,15 @@ describe('spec test', () => {
   it('base45 should fail with invalid input', () => {
     // not enough input chars, should be multiple of 3 or multiple of 3 + 2
     assert.throws(() => bases.base45.decode('R%69 VD92EX'), 'Unexpected end of data')
+  })
+
+  it('proquint should fail with invalid input', () => {
+    assert.throws(() => bases.proquint.decode('pro-lojoj-lasob-kujod-kunon-'), 'Unexpected end of data')
+    assert.throws(() => bases.proquint.decode('pro-lojoj-lasob-kujod-kunon-f'), 'Unexpected end of data')
+    assert.throws(() => bases.proquint.decode('pro-lojoj-lasob-kujod-kunon-fa'), 'Unexpected end of data')
+    assert.throws(() => bases.proquint.decode('pro-lojoj-lasob-kujod-kunon-fabo'), 'Unexpected end of data')
+    assert.throws(() => bases.proquint.decode('plojoj-lasob-kujod-kunon-fabod'), 'Invalid proquint string')
+    assert.throws(() => bases.proquint.decode('prlojoj-lasob-kujod-kunon-fabod'), 'Invalid proquint string')
+    assert.throws(() => bases.proquint.decode('prolojoj-lasob-kujod-kunon-fabod'), 'Invalid proquint string')
   })
 })

--- a/test/test-multibase-spec.spec.ts
+++ b/test/test-multibase-spec.spec.ts
@@ -25,6 +25,7 @@ const encoded = [
       ['base32z', 'het1sg3mqqt3gn5djxj11y3msci3817depfzgqejb'],
       ['base36', 'k343ixo7d49hqj1ium15pgy1wzww5fxrid21td7l'],
       ['base36upper', 'K343IXO7D49HQJ1IUM15PGY1WZWW5FXRID21TD7L'],
+      ['base45', 'R4T8KPCG/DVKEXVDDLFD44O/EALEAWEZEDV1DX0'],
       ['base58flickr', 'Ztwe7gVTeK8wswS1gf8hrgAua9fcw9reboD'],
       ['base58btc', 'zUXE7GvtEk8XTXs1GF8HSGbVA9FCX9SEBPe'],
       ['base64', 'mRGVjZW50cmFsaXplIGV2ZXJ5dGhpbmchIQ'],
@@ -54,6 +55,7 @@ const encoded = [
       ['base32z', 'hxf1zgedpcfzg1ebb'],
       ['base36', 'k2lcpzo5yikidynfl'],
       ['base36upper', 'K2LCPZO5YIKIDYNFL'],
+      ['base45', 'RRFF.OEB$D5/DZ24'],
       ['base58flickr', 'Z7Pznk19XTTzBtx'],
       ['base58btc', 'z7paNL19xttacUY'],
       ['base64', 'meWVzIG1hbmkgIQ'],
@@ -83,6 +85,7 @@ const encoded = [
       ['base32z', 'hpb1sa5dxrb5s6hucco'],
       ['base36', 'kfuvrsivvnfrbjwajo'],
       ['base36upper', 'KFUVRSIVVNFRBJWAJO'],
+      ['base45', 'R+8D VD82EK4F.KEA2'],
       ['base58flickr', 'ZrTu1dk6cWsRYjYu'],
       ['base58btc', 'zStV1DL6CwTryKyV'],
       ['base64', 'maGVsbG8gd29ybGQ'],
@@ -112,6 +115,7 @@ const encoded = [
       ['base32z', 'hybhskh3ypiosh4jyrr'],
       ['base36', 'k02lcpzo5yikidynfl'],
       ['base36upper', 'K02LCPZO5YIKIDYNFL'],
+      ['base45', 'RV206$CL44CEC2DDX0'],
       ['base58flickr', 'Z17Pznk19XTTzBtx'],
       ['base58btc', 'z17paNL19xttacUY'],
       ['base64', 'mAHllcyBtYW5pICE'],
@@ -141,6 +145,7 @@ const encoded = [
       ['base32z', 'hyyy813murbssn5ujryoo'],
       ['base36', 'k002lcpzo5yikidynfl'],
       ['base36upper', 'K002LCPZO5YIKIDYNFL'],
+      ['base45', 'R000RFF.OEB$D5/DZ24'],
       ['base58flickr', 'Z117Pznk19XTTzBtx'],
       ['base58btc', 'z117paNL19xttacUY'],
       ['base64', 'mAAB5ZXMgbWFuaSAh'],
@@ -149,7 +154,11 @@ const encoded = [
       ['base64urlpad', 'UAAB5ZXMgbWFuaSAh'],
       ['base256emoji', '🚀🚀🚀🏃✋🌈😅🌷🤤😻🌟😅👏']
     ]
-  }
+  },
+  { input: 'AB', tests: [['base45', 'RBB8']] },
+  { input: 'Hello!!', tests: [['base45', 'R%69 VD92EX0']] },
+  { input: 'base-45', tests: [['base45', 'RUJCLQE7W581']] },
+  { input: 'ietf!', tests: [['base45', 'RQED8WEX0']] }
 ]
 
 describe('spec test', () => {
@@ -160,12 +169,12 @@ describe('spec test', () => {
         const base = bases[name as keyof typeof bases]
 
         describe(name, () => {
-          it('should encode buffer', () => {
+          it(`should encode from buffer [${input}]`, () => {
             const out = base.encode(fromString(input))
             assert.deepStrictEqual(out, output)
           })
 
-          it('should decode string', () => {
+          it(`should decode from string [${input}]`, () => {
             assert.deepStrictEqual(base.decode(output), fromString(input))
           })
         })
@@ -182,4 +191,9 @@ describe('spec test', () => {
       assert.throws(() => base.decode(base.prefix + '^!@$%!#$%@#y'), `Non-${base.name} character`)
     })
   }
+
+  it('base45 should fail with invalid input', () => {
+    // not enough input chars, should be multiple of 3 or multiple of 3 + 2
+    assert.throws(() => bases.base45.decode('R%69 VD92EX'), 'Unexpected end of data')
+  })
 })

--- a/test/test-multibase.spec.ts
+++ b/test/test-multibase.spec.ts
@@ -10,6 +10,7 @@ import * as b45 from '../src/bases/base45.js'
 import * as b58 from '../src/bases/base58.js'
 import * as b64 from '../src/bases/base64.js'
 import * as b8 from '../src/bases/base8.js'
+import * as proquint from '../src/bases/proquint.js'
 import * as bytes from '../src/bytes.js'
 
 const { base16, base32, base58btc, base64 } = { ...b16, ...b32, ...b58, ...b64 }
@@ -65,7 +66,7 @@ describe('multibase', () => {
   const buff = bytes.fromString('test')
   const nonPrintableBuff = Uint8Array.from([239, 250, 254])
 
-  const baseTest = (bases: typeof b2 | typeof b8 | typeof b10 | typeof b16 | typeof b32 | typeof b36 | typeof b45 | typeof b58 | typeof b64): void => {
+  const baseTest = (bases: typeof b2 | typeof b8 | typeof b10 | typeof b16 | typeof b32 | typeof b36 | typeof b45 | typeof b58 | typeof b64 | typeof proquint): void => {
     for (const base of Object.values(bases)) {
       if (((base as { name: string })?.name) !== '') {
         it(`encode/decode ${base.name}`, () => {
@@ -121,6 +122,10 @@ describe('multibase', () => {
 
   describe('base64', () => {
     baseTest(b64)
+  })
+
+  describe('proquint', () => {
+    baseTest(proquint)
   })
 
   it('multibase mismatch', () => {

--- a/test/test-multibase.spec.ts
+++ b/test/test-multibase.spec.ts
@@ -6,6 +6,7 @@ import * as b16 from '../src/bases/base16.js'
 import * as b2 from '../src/bases/base2.js'
 import * as b32 from '../src/bases/base32.js'
 import * as b36 from '../src/bases/base36.js'
+import * as b45 from '../src/bases/base45.js'
 import * as b58 from '../src/bases/base58.js'
 import * as b64 from '../src/bases/base64.js'
 import * as b8 from '../src/bases/base8.js'
@@ -64,7 +65,7 @@ describe('multibase', () => {
   const buff = bytes.fromString('test')
   const nonPrintableBuff = Uint8Array.from([239, 250, 254])
 
-  const baseTest = (bases: typeof b2 | typeof b8 | typeof b10 | typeof b16 | typeof b32 | typeof b36 | typeof b58 | typeof b64): void => {
+  const baseTest = (bases: typeof b2 | typeof b8 | typeof b10 | typeof b16 | typeof b32 | typeof b36 | typeof b45 | typeof b58 | typeof b64): void => {
     for (const base of Object.values(bases)) {
       if (((base as { name: string })?.name) !== '') {
         it(`encode/decode ${base.name}`, () => {
@@ -108,6 +109,10 @@ describe('multibase', () => {
 
   describe('base36', () => {
     baseTest(b36)
+  })
+
+  describe('base45', () => {
+    baseTest(b45)
   })
 
   describe('base58', () => {

--- a/typedoc.json
+++ b/typedoc.json
@@ -7,6 +7,7 @@
     "./src/bases/base256emoji.ts",
     "./src/bases/base32.ts",
     "./src/bases/base36.ts",
+    "./src/bases/base45.ts",
     "./src/bases/base58.ts",
     "./src/bases/base64.ts",
     "./src/bases/base8.ts",


### PR DESCRIPTION
I've got fairly low confidence in this, but I had fun doing it.

From what I can see, reference implementations depend on being able to read inputs as 8-bit pairs (i.e. encode and decode in 16-bit chunks), but we need more flexibility than that for multibase so I've taken some liberties in defining what an uneven number of input bytes would do, which you can see in the test fixtures, i.e. instead of a 5 character block, it's a 3 character block, so we overspend by 2 bits.

Need to find other implementations that deal in variable input and output bytes and not just strict 16 or 32 bit ints.

Anyone want to help!?