### PR TITLE
feat: BlockCodec methods are generic

### DIFF
--- a/src/codecs/interface.ts
+++ b/src/codecs/interface.ts
@@ -3,23 +3,23 @@ import type { ArrayBufferView, ByteView } from '../block/interface.js'
 /**
  * IPLD encoder part of the codec.
  */
-export interface BlockEncoder<Code extends number, T> {
+export interface BlockEncoder<Code extends number, Universe> {
   name: string
   code: Code
-  encode(data: T): ByteView<T>
+  encode<T extends Universe>(data: T): ByteView<T>
 }
 
 /**
  * IPLD decoder part of the codec.
  */
-export interface BlockDecoder<Code extends number, T> {
+export interface BlockDecoder<Code extends number, Universe> {
   code: Code
-  decode(bytes: ByteView<T> | ArrayBufferView<T>): T
+  decode<T extends Universe>(bytes: ByteView<T> | ArrayBufferView<T>): T
 }
 
 /**
  * An IPLD codec is a combination of both encoder and decoder.
  */
-export interface BlockCodec<Code extends number, T> extends BlockEncoder<Code, T>, BlockDecoder<Code, T> {}
+export interface BlockCodec<Code extends number, Universe> extends BlockEncoder<Code, Universe>, BlockDecoder<Code, Universe> {}
 
 export type { ArrayBufferView, ByteView }


### PR DESCRIPTION
Adds support for generic types to the `encode` and `decode` methods on
the `BlockCodec` interface.

I don't believe this to be a breaking change as the generic type is inferred by the
typescript compiler and will only be a narrowing of the `Universe` generic type on `BlockCodec`, previously named `T`.

Related: https://github.com/multiformats/js-multiformats/issues/293