### PR TITLE
fix: revert "feat: BlockCodec methods are generic"

### DIFF
--- a/src/codecs/interface.ts
+++ b/src/codecs/interface.ts
@@ -3,23 +3,23 @@ import type { ArrayBufferView, ByteView } from '../block/interface.js'
 /**
  * IPLD encoder part of the codec.
  */
-export interface BlockEncoder<Code extends number, Universe> {
+export interface BlockEncoder<Code extends number, T> {
   name: string
   code: Code
-  encode<T extends Universe>(data: T): ByteView<T>
+  encode(data: T): ByteView<T>
 }
 
 /**
  * IPLD decoder part of the codec.
  */
-export interface BlockDecoder<Code extends number, Universe> {
+export interface BlockDecoder<Code extends number, T> {
   code: Code
-  decode<T extends Universe>(bytes: ByteView<T> | ArrayBufferView<T>): T
+  decode(bytes: ByteView<T> | ArrayBufferView<T>): T
 }
 
 /**
  * An IPLD codec is a combination of both encoder and decoder.
  */
-export interface BlockCodec<Code extends number, Universe> extends BlockEncoder<Code, Universe>, BlockDecoder<Code, Universe> {}
+export interface BlockCodec<Code extends number, T> extends BlockEncoder<Code, T>, BlockDecoder<Code, T> {}
 
 export type { ArrayBufferView, ByteView }


### PR DESCRIPTION
Reverts multiformats/js-multiformats#294

Ref: #300 

@tabcat