### PR TITLE
enable the BlockEncoder to use promise API in encode/decode methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -278,7 +278,8 @@
     "aegir": "^43.0.1",
     "buffer": "^6.0.3",
     "cids": "^1.1.9",
-    "crypto-hash": "^3.0.0"
+    "crypto-hash": "^3.0.0",
+    "mocha": "^10.7.0"
   },
   "aegir": {
     "test": {

--- a/src/block.ts
+++ b/src/block.ts
@@ -141,7 +141,7 @@ export async function encode <T, Code extends number, Alg extends number> ({ val
   if (typeof value === 'undefined') throw new Error('Missing required argument "value"')
   if (codec == null || hasher == null) throw new Error('Missing required argument: codec or hasher')
 
-  const bytes = codec.encode(value)
+  const bytes = await Promise.resolve(codec.encode(value))
   const hash = await hasher.digest(bytes)
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
   const cid = CID.create(
@@ -168,7 +168,7 @@ export async function decode <T, Code extends number, Alg extends number> ({ byt
   if (bytes == null) throw new Error('Missing required argument "bytes"')
   if (codec == null || hasher == null) throw new Error('Missing required argument: codec or hasher')
 
-  const value = codec.decode(bytes)
+  const value = await Promise.resolve(codec.decode(bytes))
   const hash = await hasher.digest(bytes)
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
   const cid = CID.create(1, codec.code, hash) as CID<T, Code, Alg, 1>
@@ -194,10 +194,10 @@ type CreateUnsafeInput <T, Code extends number, Alg extends number, V extends AP
  * @template Alg - multicodec code corresponding to the hashing algorithm used in CID creation.
  * @template V - CID version
  */
-export function createUnsafe <T, Code extends number, Alg extends number, V extends API.Version> ({ bytes, cid, value: maybeValue, codec }: CreateUnsafeInput<T, Code, Alg, V>): API.BlockView<T, Code, Alg, V> {
-  const value = maybeValue !== undefined
+export async function createUnsafe <T, Code extends number, Alg extends number, V extends API.Version> ({ bytes, cid, value: maybeValue, codec }: CreateUnsafeInput<T, Code, Alg, V>): Promise<API.BlockView<T, Code, Alg, V>> {
+  const value = await Promise.resolve(maybeValue !== undefined
     ? maybeValue
-    : (codec?.decode(bytes))
+    : (codec?.decode(bytes)))
 
   if (value === undefined) throw new Error('Missing required argument, must either provide "value" or "codec"')
 
@@ -224,7 +224,7 @@ interface CreateInput <T, Code extends number, Alg extends number, V extends API
 export async function create <T, Code extends number, Alg extends number, V extends API.Version> ({ bytes, cid, hasher, codec }: CreateInput<T, Code, Alg, V>): Promise<API.BlockView<T, Code, Alg, V>> {
   if (bytes == null) throw new Error('Missing required argument "bytes"')
   if (hasher == null) throw new Error('Missing required argument "hasher"')
-  const value = codec.decode(bytes)
+  const value = await Promise.resolve(codec.decode(bytes))
   const hash = await hasher.digest(bytes)
   if (!binary.equals(cid.multihash.bytes, hash.bytes)) {
     throw new Error('CID hash does not match bytes')

--- a/src/codecs/interface.ts
+++ b/src/codecs/interface.ts
@@ -6,7 +6,7 @@ import type { ArrayBufferView, ByteView } from '../block/interface.js'
 export interface BlockEncoder<Code extends number, T> {
   name: string
   code: Code
-  encode(data: T): ByteView<T>
+  encode(data: T): ByteView<T> | PromiseLike<ByteView<T>>
 }
 
 /**
@@ -14,7 +14,7 @@ export interface BlockEncoder<Code extends number, T> {
  */
 export interface BlockDecoder<Code extends number, T> {
   code: Code
-  decode(bytes: ByteView<T> | ArrayBufferView<T>): T
+  decode(bytes: ByteView<T> | ArrayBufferView<T>): T | PromiseLike<T>
 }
 
 /**

--- a/test/test-multibase-spec.spec.ts
+++ b/test/test-multibase-spec.spec.ts
@@ -174,9 +174,11 @@ describe('spec test', () => {
   }
 
   for (const base of Object.values(bases)) {
-    it('should fail decode with invalid char', function () {
+    // eslint-disable-next-line @typescript-eslint/method-signature-style
+    it('should fail decode with invalid char', function (this: { skip: () => void }) {
       if (base.name === 'identity') {
-        return this.skip()
+        this.skip()
+        return
       }
 
       assert.throws(() => base.decode(base.prefix + '^!@$%!#$%@#y'), `Non-${base.name} character`)


### PR DESCRIPTION
      Enable the BlockEncoder to use promise API in encode/decode methods.
      Why we need that:
        https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto
      To enable the promise to encode/decode a breaking change to 
      createUnsafe is required.
      The existing signature of createUnsafe can not pass a promise.
      Therefore the tests need to change.
      For me, measuring the blast radius of the change is impossible.
      If the blast radius is too big then there is still the possibility to
      create a new method createUnsafeAsync and throw an error
      in the createUnsafe if the decode sends a promise.
      
 