### PR TITLE
feat: add hasCode to Digest

### DIFF
--- a/src/hashes/digest.ts
+++ b/src/hashes/digest.ts
@@ -69,3 +69,10 @@ export class Digest<Code extends number, Size extends number> implements Multiha
     this.bytes = bytes
   }
 }
+
+/**
+ * Used to check that the passed multihash has the passed code
+ */
+export function hasCode <T extends number> (digest: MultihashDigest, code: T): digest is MultihashDigest<T> {
+  return digest.code === code
+}

--- a/src/hashes/identity.ts
+++ b/src/hashes/identity.ts
@@ -1,7 +1,7 @@
 import { coerce } from '../bytes.js'
 import * as Digest from './digest.js'
 
-const code = 0x0
+const code: 0x0 = 0x0
 const name = 'identity'
 
 const encode: (input: Uint8Array) => Uint8Array = coerce


### PR DESCRIPTION
To give a hint to tsc that a `MultihashDigest` has a specific code, add a disambiguator `hasCode` function.

This lets us define functions that require a certain multihash code with type saftey.