### PR TITLE
fix!: identity hash is Hasher<"identity", 0>

### DIFF
--- a/src/hashes/identity.ts
+++ b/src/hashes/identity.ts
@@ -1,13 +1,13 @@
 import { coerce } from '../bytes.js'
-import * as Digest from './digest.js'
+import { from } from './hasher.js'
 
 const code: 0x0 = 0x0
 const name = 'identity'
 
 const encode: (input: Uint8Array) => Uint8Array = coerce
 
-function digest (input: Uint8Array): Digest.Digest<typeof code, number> {
-  return Digest.create(code, encode(input))
-}
-
-export const identity = { code, name, encode, digest }
+export const identity = from({
+  name,
+  code,
+  encode
+})

--- a/test/test-multihash.spec.ts
+++ b/test/test-multihash.spec.ts
@@ -97,20 +97,8 @@ describe('multihash', () => {
       assert.deepStrictEqual(hash2.bytes, hash.bytes)
     })
 
-    it('hash identity async', async () => {
-      // eslint-disable-next-line @typescript-eslint/await-thenable
+    it('hash identity', async () => {
       const hash = await identity.digest(fromString('test'))
-      assert.deepStrictEqual(hash.code, identity.code)
-      assert.deepStrictEqual(identity.code, 0)
-      assert.deepStrictEqual(hash.digest, fromString('test'))
-
-      const hash2 = decodeDigest(hash.bytes)
-      assert.deepStrictEqual(hash2.code, identity.code)
-      assert.deepStrictEqual(hash2.bytes, hash.bytes)
-    })
-
-    it('hash identity sync', () => {
-      const hash = identity.digest(fromString('test'))
       assert.deepStrictEqual(hash.code, identity.code)
       assert.deepStrictEqual(identity.code, 0)
       assert.deepStrictEqual(hash.digest, fromString('test'))
@@ -161,11 +149,12 @@ describe('multihash', () => {
   })
 
   describe('hasCode', () => {
-    it('asserts that a multihash has the expected code', () => {
+    it('asserts that a multihash has the expected code', async () => {
       const buf = Uint8Array.from([0, 1, 2, 3])
 
       // remove code type from MultihashDigest
-      const hash = decodeDigest(identity.digest(buf).bytes)
+      const digest = await identity.digest(buf)
+      const hash = decodeDigest(digest.bytes)
 
       // a function that requires a specific type of multihash
       function needIdentity (_: MultihashDigest<0x0>): void {

--- a/test/test-multihash.spec.ts
+++ b/test/test-multihash.spec.ts
@@ -108,7 +108,7 @@ describe('multihash', () => {
       assert.deepStrictEqual(hash2.bytes, hash.bytes)
     })
 
-    it('hash identity sync', async () => {
+    it('hash identity sync', () => {
       const hash = identity.digest(fromString('test'))
 
       if (hash instanceof Promise) {

--- a/test/test-multihash.spec.ts
+++ b/test/test-multihash.spec.ts
@@ -107,6 +107,22 @@ describe('multihash', () => {
       assert.deepStrictEqual(hash2.code, identity.code)
       assert.deepStrictEqual(hash2.bytes, hash.bytes)
     })
+
+    it('hash identity sync', async () => {
+      const hash = identity.digest(fromString('test'))
+
+      if (hash instanceof Promise) {
+        assert.fail('expected sync result')
+      } else {
+        assert.deepStrictEqual(hash.code, identity.code)
+        assert.deepStrictEqual(identity.code, 0)
+        assert.deepStrictEqual(hash.digest, fromString('test'))
+
+        const hash2 = decodeDigest(hash.bytes)
+        assert.deepStrictEqual(hash2.code, identity.code)
+        assert.deepStrictEqual(hash2.bytes, hash.bytes)
+      }
+    })
   })
   describe('decode', () => {
     for (const { encoding, hex, size } of valid) {


### PR DESCRIPTION
Breaking change because return type no longer supports sync (aligns with other hashers)

Fixes https://github.com/multiformats/js-multiformats/issues/313
