### PR TITLE
fix: enforce max identity digest size

### DIFF
--- a/src/hashes/digest.ts
+++ b/src/hashes/digest.ts
@@ -1,5 +1,6 @@
 import { coerce, equals as equalBytes } from '../bytes.js'
 import * as varint from '../varint.js'
+import { identity } from './identity.js'
 import type { MultihashDigest } from './interface.js'
 
 /**
@@ -29,6 +30,9 @@ export function decode (multihash: Uint8Array): MultihashDigest {
 
   if (digest.byteLength !== size) {
     throw new Error('Incorrect length')
+  }
+  if (code === 0x0 && size > identity.DefaultMaxIdentityDigestSize) {
+    throw new Error(`Identity digest exceeds maximum size of ${identity.DefaultMaxIdentityDigestSize} bytes`)
   }
 
   return new Digest(code, size, digest, bytes)

--- a/src/hashes/identity.ts
+++ b/src/hashes/identity.ts
@@ -5,6 +5,8 @@ import type { DigestOptions } from './hasher.js'
 const code: 0x0 = 0x0
 const name = 'identity'
 
+const DefaultMaxIdentityDigestSize = 128
+
 const encode: (input: Uint8Array) => Uint8Array = coerce
 
 function digest (input: Uint8Array, options?: DigestOptions): Digest.Digest<typeof code, number> {
@@ -16,7 +18,11 @@ function digest (input: Uint8Array, options?: DigestOptions): Digest.Digest<type
     input = input.subarray(0, options.truncate)
   }
 
+  if (input.byteLength > DefaultMaxIdentityDigestSize) {
+    throw new Error(`Identity digest exceeds maximum size of ${DefaultMaxIdentityDigestSize} bytes`)
+  }
+
   return Digest.create(code, encode(input))
 }
 
-export const identity = { code, name, encode, digest }
+export const identity = { code, name, encode, digest, DefaultMaxIdentityDigestSize }

--- a/test/test-multihash.spec.ts
+++ b/test/test-multihash.spec.ts
@@ -2,7 +2,7 @@
 
 import { hash as slSha256 } from '@stablelib/sha256'
 import { hash as slSha512 } from '@stablelib/sha512'
-import { assert } from 'aegir/chai'
+import { assert, expect } from 'aegir/chai'
 import { sha1 as chSha1 } from 'crypto-hash'
 import { fromHex, fromString } from '../src/bytes.js'
 import { decode as decodeDigest, create as createDigest, hasCode as digestHasCode } from '../src/hashes/digest.js'
@@ -170,6 +170,11 @@ describe('multihash', () => {
       const hash2 = decodeDigest(hash.bytes)
       assert.deepStrictEqual(hash2.code, identity.code)
       assert.deepStrictEqual(hash2.bytes, hash.bytes)
+    })
+
+    it('hash identity oversized', () => {
+      const oversized = new Uint8Array(129).fill(0x61)
+      expect(() => identity.digest(oversized)).to.throw(/Identity digest exceeds maximum size of 128 bytes/)
     })
 
     it('hash identity truncated', async () => {


### PR DESCRIPTION
Enforces a maximum digest size of **128 bytes** for identity multihashes.

In ipfs/helia, currently allows creation of identity CIDs with arbitrarily large digests. 
This can lead to oversized inline CIDs being generated, which poses risks for gateways and blockstores (DoS, unbounded memory growth, etc)

ref: [ipfs/helia#846](https://github.com/ipfs/helia/issues/846)