### PR TITLE
fix!: identity hash is SyncMultihashHasher<0>

### DIFF
--- a/src/hashes/hasher.ts
+++ b/src/hashes/hasher.ts
@@ -8,7 +8,7 @@ const DEFAULT_MIN_DIGEST_LENGTH = 20
 export interface HasherInit <Name extends string, Code extends number> {
   name: Name
   code: Code
-  encode(input: Uint8Array): Await<Uint8Array>
+  encode(input: Uint8Array): Await<Uint8Array<ArrayBuffer>>
 
   /**
    * The minimum length a hash is allowed to be truncated to in bytes
@@ -24,7 +24,7 @@ export interface HasherInit <Name extends string, Code extends number> {
   maxDigestLength?: number
 }
 
-export function from <Name extends string, Code extends number> ({ name, code, encode, minDigestLength, maxDigestLength }: HasherInit<Name, Code>): Hasher<Name, Code> {
+export function from <Name extends string, Code extends number> ({ name, code, encode, minDigestLength, maxDigestLength }: HasherInit<Name, Code>): MultihashHasher<Code> {
   return new Hasher(name, code, encode, minDigestLength, maxDigestLength)
 }
 
@@ -49,11 +49,11 @@ export interface DigestOptions {
 export class Hasher<Name extends string, Code extends number> implements MultihashHasher<Code> {
   readonly name: Name
   readonly code: Code
-  readonly encode: (input: Uint8Array) => Await<Uint8Array>
+  readonly encode: (input: Uint8Array) => Await<Uint8Array<ArrayBuffer>>
   readonly minDigestLength: number
   readonly maxDigestLength?: number
 
-  constructor (name: Name, code: Code, encode: (input: Uint8Array) => Await<Uint8Array>, minDigestLength?: number, maxDigestLength?: number) {
+  constructor (name: Name, code: Code, encode: (input: Uint8Array) => Await<Uint8Array<ArrayBuffer>>, minDigestLength?: number, maxDigestLength?: number) {
     this.name = name
     this.code = code
     this.encode = encode

--- a/src/hashes/identity.ts
+++ b/src/hashes/identity.ts
@@ -1,11 +1,12 @@
 import { coerce } from '../bytes.ts'
 import * as Digest from './digest.ts'
 import type { DigestOptions } from './hasher.ts'
+import type { SyncMultihashHasher } from './interface.ts'
 
 const code: 0x0 = 0x0
 const name = 'identity'
 
-const encode: (input: Uint8Array) => Uint8Array = coerce
+const encode: (input: Uint8Array) => Uint8Array<ArrayBuffer> = coerce
 
 function digest (input: Uint8Array, options?: DigestOptions): Digest.Digest<typeof code, number> {
   if (options?.truncate != null && options.truncate !== input.byteLength) {
@@ -19,4 +20,4 @@ function digest (input: Uint8Array, options?: DigestOptions): Digest.Digest<type
   return Digest.create(code, encode(input))
 }
 
-export const identity = { code, name, encode, digest }
+export const identity: SyncMultihashHasher<0x00> = { code, name, encode, digest }

--- a/src/hashes/interface.ts
+++ b/src/hashes/interface.ts
@@ -47,6 +47,12 @@ export interface MultihashHasher<Code extends number = number> {
   digest(input: Uint8Array, options?: DigestOptions): Promise<MultihashDigest<Code>> | MultihashDigest<Code>
 
   /**
+   * Returns the raw digest representation of the binary input (e.g. without
+   * hashing codec)
+   */
+  encode(input: Uint8Array): Promise<Uint8Array<ArrayBuffer>> | Uint8Array<ArrayBuffer>
+
+  /**
    * Name of the multihash
    */
   name: string
@@ -69,4 +75,5 @@ export interface MultihashHasher<Code extends number = number> {
  */
 export interface SyncMultihashHasher<Code extends number = number> extends MultihashHasher<Code> {
   digest(input: Uint8Array, options?: DigestOptions): MultihashDigest<Code>
+  encode(input: Uint8Array): Uint8Array<ArrayBuffer>
 }

--- a/src/hashes/sha1-browser.ts
+++ b/src/hashes/sha1-browser.ts
@@ -1,5 +1,3 @@
-/* global crypto */
-
 import { from } from './hasher.ts'
 
 const sha = (name: AlgorithmIdentifier) =>

--- a/src/hashes/sha2-browser.ts
+++ b/src/hashes/sha2-browser.ts
@@ -1,8 +1,6 @@
-/* global crypto */
-
 import { from } from './hasher.ts'
 
-function sha (name: AlgorithmIdentifier): (data: Uint8Array<ArrayBuffer>) => Promise<Uint8Array> {
+function sha (name: AlgorithmIdentifier): (data: Uint8Array<ArrayBuffer>) => Promise<Uint8Array<ArrayBuffer>> {
   return async data => new Uint8Array(await crypto.subtle.digest(name, data))
 }
 


### PR DESCRIPTION
Updates the type of the identity hash to `SyncMultihashHasher<0x00>` to enable passing it where `MultihashHasher<Code>` instances are expected.

It was also necessary to update the returned type of `from` to be `MultihashHasher<Code>` instead of the concrete `Hasher` type which has extra properties that are not part of hashing.

Fixes #313
Supersedes #314

BREAKING CHANGE: all `Hasher`s are now `MultihashHasher<Code>`s