### PR TITLE
fix: verify CID hash before decoding in Block.create

### DIFF
--- a/src/block.ts
+++ b/src/block.ts
@@ -224,7 +224,7 @@ interface CreateInput <T, Code extends number, Alg extends number, V extends API
 export async function create <T, Code extends number, Alg extends number, V extends API.Version> ({ bytes, cid, hasher, codec }: CreateInput<T, Code, Alg, V>): Promise<API.BlockView<T, Code, Alg, V>> {
   if (bytes == null) { throw new Error('Missing required argument "bytes"') }
   if (hasher == null) { throw new Error('Missing required argument "hasher"') }
-  const value = codec.decode(bytes)
+
   const hash = await hasher.digest(bytes)
   if (!binary.equals(cid.multihash.bytes, hash.bytes)) {
     throw new Error('CID hash does not match bytes')
@@ -233,7 +233,6 @@ export async function create <T, Code extends number, Alg extends number, V exte
   return createUnsafe({
     bytes,
     cid,
-    value,
     codec
   })
 }

--- a/test/test-block.spec.ts
+++ b/test/test-block.spec.ts
@@ -145,6 +145,15 @@ describe('block', () => {
       await assert.isRejected(main.create({ bytes: block.bytes, cid: block2.cid, codec, hasher }), 'CID hash does not match bytes')
     })
 
+    it('create verifies the cid hash before decoding the bytes', async () => {
+      const block = await main.encode({ value: fixture, codec, hasher })
+      const badBytes = bytes.fromString('not valid json')
+      await assert.isRejected(
+        main.create({ bytes: badBytes, cid: block.cid, codec, hasher }),
+        'CID hash does not match bytes'
+      )
+    })
+
     it('get', async () => {
       const block = await main.encode({ value: fixture, codec, hasher })
       assert.throws(() => block.get('/asd/fs/dfasd/f'), 'Object has no property at ["asd"]')


### PR DESCRIPTION
`Block.create` is the verifying block constructor, but it decoded `bytes` before checking they matched the CID, so the codec parser ran on unverified, potentially untrusted input.

This hashes and compares first, then delegates decoding to `createUnsafe`. Valid blocks are unchanged; bytes that don't match the CID are now rejected without ever being decoded, and such input always throws the hash-mismatch error rather than possibly a codec error first.

Adds a test asserting mismatched, codec-invalid bytes reject with the hash error (i.e. decode never runs).

Closes #339
