### PR TITLE
fix: case-insensitive decode for base16/base32/base36 (multibase spec)

### DIFF
--- a/src/bases/base.ts
+++ b/src/bases/base.ts
@@ -130,8 +130,8 @@ export function from <Base extends string, Prefix extends string> ({ name, prefi
   return new Codec(name, prefix, encode, decode)
 }
 
-export function baseX <Base extends string, Prefix extends string> ({ name, prefix, alphabet }: { name: Base, prefix: Prefix, alphabet: string }): Codec<Base, Prefix> {
-  const { encode, decode } = basex(alphabet, name)
+export function baseX <Base extends string, Prefix extends string> ({ name, prefix, alphabet, caseInsensitive = false }: { name: Base, prefix: Prefix, alphabet: string, caseInsensitive?: boolean }): Codec<Base, Prefix> {
+  const { encode, decode } = basex(alphabet, name, caseInsensitive)
   return from({
     prefix,
     name,
@@ -214,11 +214,23 @@ function encode (data: Uint8Array, alphabet: string, bitsPerChar: number): strin
   return out
 }
 
-function createAlphabetIdx (alphabet: string): Record<string, number> {
+function createAlphabetIdx (alphabet: string, caseInsensitive: boolean): Record<string, number> {
   // Build the character lookup table:
   const alphabetIdx: Record<string, number> = {}
   for (let i = 0; i < alphabet.length; ++i) {
     alphabetIdx[alphabet[i]] = i
+    // For case-insensitive codecs, map the opposite case to the same index so
+    // differently cased input decodes without errors (multibase spec).
+    if (caseInsensitive) {
+      const lower = alphabet[i].toLowerCase()
+      const upper = alphabet[i].toUpperCase()
+      if (lower !== alphabet[i]) {
+        alphabetIdx[lower] = i
+      }
+      if (upper !== alphabet[i]) {
+        alphabetIdx[upper] = i
+      }
+    }
   }
   return alphabetIdx
 }
@@ -226,8 +238,8 @@ function createAlphabetIdx (alphabet: string): Record<string, number> {
 /**
  * RFC4648 Factory
  */
-export function rfc4648 <Base extends string, Prefix extends string> ({ name, prefix, bitsPerChar, alphabet }: { name: Base, prefix: Prefix, bitsPerChar: number, alphabet: string }): Codec<Base, Prefix> {
-  const alphabetIdx = createAlphabetIdx(alphabet)
+export function rfc4648 <Base extends string, Prefix extends string> ({ name, prefix, bitsPerChar, alphabet, caseInsensitive = false }: { name: Base, prefix: Prefix, bitsPerChar: number, alphabet: string, caseInsensitive?: boolean }): Codec<Base, Prefix> {
+  const alphabetIdx = createAlphabetIdx(alphabet, caseInsensitive)
   return from({
     prefix,
     name,

--- a/src/bases/base16.ts
+++ b/src/bases/base16.ts
@@ -4,12 +4,14 @@ export const base16 = rfc4648({
   prefix: 'f',
   name: 'base16',
   alphabet: '0123456789abcdef',
-  bitsPerChar: 4
+  bitsPerChar: 4,
+  caseInsensitive: true
 })
 
 export const base16upper = rfc4648({
   prefix: 'F',
   name: 'base16upper',
   alphabet: '0123456789ABCDEF',
-  bitsPerChar: 4
+  bitsPerChar: 4,
+  caseInsensitive: true
 })

--- a/src/bases/base32.ts
+++ b/src/bases/base32.ts
@@ -4,56 +4,64 @@ export const base32 = rfc4648({
   prefix: 'b',
   name: 'base32',
   alphabet: 'abcdefghijklmnopqrstuvwxyz234567',
-  bitsPerChar: 5
+  bitsPerChar: 5,
+  caseInsensitive: true
 })
 
 export const base32upper = rfc4648({
   prefix: 'B',
   name: 'base32upper',
   alphabet: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567',
-  bitsPerChar: 5
+  bitsPerChar: 5,
+  caseInsensitive: true
 })
 
 export const base32pad = rfc4648({
   prefix: 'c',
   name: 'base32pad',
   alphabet: 'abcdefghijklmnopqrstuvwxyz234567=',
-  bitsPerChar: 5
+  bitsPerChar: 5,
+  caseInsensitive: true
 })
 
 export const base32padupper = rfc4648({
   prefix: 'C',
   name: 'base32padupper',
   alphabet: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567=',
-  bitsPerChar: 5
+  bitsPerChar: 5,
+  caseInsensitive: true
 })
 
 export const base32hex = rfc4648({
   prefix: 'v',
   name: 'base32hex',
   alphabet: '0123456789abcdefghijklmnopqrstuv',
-  bitsPerChar: 5
+  bitsPerChar: 5,
+  caseInsensitive: true
 })
 
 export const base32hexupper = rfc4648({
   prefix: 'V',
   name: 'base32hexupper',
   alphabet: '0123456789ABCDEFGHIJKLMNOPQRSTUV',
-  bitsPerChar: 5
+  bitsPerChar: 5,
+  caseInsensitive: true
 })
 
 export const base32hexpad = rfc4648({
   prefix: 't',
   name: 'base32hexpad',
   alphabet: '0123456789abcdefghijklmnopqrstuv=',
-  bitsPerChar: 5
+  bitsPerChar: 5,
+  caseInsensitive: true
 })
 
 export const base32hexpadupper = rfc4648({
   prefix: 'T',
   name: 'base32hexpadupper',
   alphabet: '0123456789ABCDEFGHIJKLMNOPQRSTUV=',
-  bitsPerChar: 5
+  bitsPerChar: 5,
+  caseInsensitive: true
 })
 
 export const base32z = rfc4648({

--- a/src/bases/base36.ts
+++ b/src/bases/base36.ts
@@ -3,11 +3,13 @@ import { baseX } from './base.ts'
 export const base36 = baseX({
   prefix: 'k',
   name: 'base36',
-  alphabet: '0123456789abcdefghijklmnopqrstuvwxyz'
+  alphabet: '0123456789abcdefghijklmnopqrstuvwxyz',
+  caseInsensitive: true
 })
 
 export const base36upper = baseX({
   prefix: 'K',
   name: 'base36upper',
-  alphabet: '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+  alphabet: '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+  caseInsensitive: true
 })

--- a/src/vendor/base-x.d.ts
+++ b/src/vendor/base-x.d.ts
@@ -6,4 +6,4 @@ export interface BaseConverter {
     decode(string: string): Uint8Array;
 }
 
-export default function base(ALPHABET: string, name: string): BaseConverter
+export default function base(ALPHABET: string, name: string, caseInsensitive?: boolean): BaseConverter

--- a/src/vendor/base-x.js
+++ b/src/vendor/base-x.js
@@ -7,8 +7,9 @@
 /**
  * @param {string} ALPHABET
  * @param {any} name
+ * @param {boolean} [caseInsensitive]
  */
-function base (ALPHABET, name) {
+function base (ALPHABET, name, caseInsensitive) {
   if (ALPHABET.length >= 255) { throw new TypeError('Alphabet too long') }
   var BASE_MAP = new Uint8Array(256);
   for (var j = 0; j < BASE_MAP.length; j++) {
@@ -19,6 +20,14 @@ function base (ALPHABET, name) {
     var xc = x.charCodeAt(0);
     if (BASE_MAP[xc] !== 255) { throw new TypeError(x + ' is ambiguous') }
     BASE_MAP[xc] = i;
+    // For case-insensitive codecs, map the opposite case to the same index so
+    // differently cased input decodes without errors (multibase spec).
+    if (caseInsensitive) {
+      var xl = x.toLowerCase().charCodeAt(0);
+      var xu = x.toUpperCase().charCodeAt(0);
+      if (xl !== xc) { BASE_MAP[xl] = i; }
+      if (xu !== xc) { BASE_MAP[xu] = i; }
+    }
   }
   var BASE = ALPHABET.length;
   var LEADER = ALPHABET.charAt(0);

--- a/test/test-multibase-spec.spec.ts
+++ b/test/test-multibase-spec.spec.ts
@@ -150,6 +150,24 @@ const encoded = [
   }
 ]
 
+// Differently cased than the canonical encoding. Per the multibase spec
+// `tests/case_insensitivity.csv` fixture, these must decode without errors.
+// Every value below encodes 'hello world'.
+const caseInsensitive: Array<[string, string]> = [
+  ['base16', 'f68656c6c6f20776F726C64'],
+  ['base16upper', 'F68656c6c6f20776F726C64'],
+  ['base32', 'bnbswy3dpeB3W64TMMQ'],
+  ['base32upper', 'Bnbswy3dpeB3W64TMMQ'],
+  ['base32hex', 'vd1imor3f41RMUSJCCG'],
+  ['base32hexupper', 'Vd1imor3f41RMUSJCCG'],
+  ['base32pad', 'cnbswy3dpeB3W64TMMQ======'],
+  ['base32padupper', 'Cnbswy3dpeB3W64TMMQ======'],
+  ['base32hexpad', 'td1imor3f41RMUSJCCG======'],
+  ['base32hexpadupper', 'Td1imor3f41RMUSJCCG======'],
+  ['base36', 'kfUvrsIvVnfRbjWaJo'],
+  ['base36upper', 'KfUVrSIVVnFRbJWAJo']
+]
+
 describe('spec test', () => {
   let index = 0
   for (const { input, tests } of encoded) {
@@ -180,4 +198,14 @@ describe('spec test', () => {
       assert.throws(() => base.decode(base.prefix + '^!@$%!#$%@#y'), `Non-${base.name} character`)
     })
   }
+
+  describe('case insensitivity', () => {
+    for (const [name, output] of caseInsensitive) {
+      const base = bases[name as keyof typeof bases]
+
+      it(`${name} should decode differently cased input`, () => {
+        assert.deepStrictEqual(base.decode(output), fromString('hello world'))
+      })
+    }
+  })
 })


### PR DESCRIPTION
## Problem

The multibase registry marks several codecs as **case-insensitive**: `base16`, `base16upper`, `base32`, `base32upper`, `base32pad`, `base32padupper`, `base32hex`, `base32hexupper`, `base32hexpad`, `base32hexpadupper`, `base36`, `base36upper`.

The multibase spec test suite (`tests/README.md`) describes `case_insensitivity.csv` as:

> `case_insensitivity.csv` | `hello world` | Differently cased than expected, must decode without errors

On the current code these decoders throw on differently cased input. Every line below encodes `hello world` (hex `68656c6c6f20776f726c64`):

```js
import { base16 } from 'multiformats/bases/base16'
import { base32 } from 'multiformats/bases/base32'
import { base36 } from 'multiformats/bases/base36'

base16.decode('f68656c6c6f20776F726C64')   // throws: Non-base16 character
base32.decode('bnbswy3dpeB3W64TMMQ')        // throws: Non-base32 character
base36.decode('kfUvrsIvVnfRbjWaJo')         // throws: Non-base36 character
```

All 12 lines of the spec's `case_insensitivity.csv` fail this way. The other three official fixtures (`basic`, `leading_zero`, `two_leading_zeros`) already pass, so this is purely the case-insensitivity gap. The repo's own `test/test-multibase-spec.spec.ts` carries the basic fixtures inline but omits `case_insensitivity.csv`, which hid the gap.

This matters for interop: a multibase string produced by a case-insensitive-tolerant implementation (for example go-multibase output that was upper/lower-folded in transit) does not decode in JS today.

## References

- multibase `tests/case_insensitivity.csv` fixture ("must decode without errors").
- multibase `README.md` registry table marks these codecs case-insensitive.
- RFC 4648 section 3.4 (base16/base32): decoders accept either case.
- go-multibase routes base16 through `hex.DecodeString` (case-insensitive) and base32 through case-insensitive decoders, and `multibase_test.go` tampers case for case-insensitive codecs and requires decode to succeed.

## Fix

Thread an optional `caseInsensitive` flag from the `rfc4648` and `baseX` factories. When set, the decode lookup table maps both the lower and upper case of each alphabet character to the same index. The flag is enabled only for the spec-designated codecs above.

Scope notes:

- Only **decode** becomes case-insensitive. Encode output is unchanged and stays canonical (lowercase or uppercase per codec).
- Case-sensitive codecs (`base58btc`, `base58flickr`, `base64`, `base64url`, `base64pad`, `base256emoji`, `identity`, `base2`, `base8`, `base10`) keep the default `false` and are unaffected. `base32z` is not in the case-insensitive registry and is left case-sensitive.

## Tests

Added a `case insensitivity` block to `test/test-multibase-spec.spec.ts` using the exact 12 fixture strings from the spec's `case_insensitivity.csv`, asserting each decodes to `hello world`. These tests fail on `master` and pass with this change. The full node suite is green (478 passing), encode output is byte-identical, and case-sensitive codecs still reject mixed case.
