### PR TITLE
fix: allow specifying ByteView backing type

### DIFF
--- a/src/block/interface.ts
+++ b/src/block/interface.ts
@@ -10,7 +10,7 @@ import type { Link, Version } from '../link/interface.ts'
  * For example, a `ByteView<{ hello: "world" }>` is a `Uint8Array` containing a
  * binary representation of a `{hello: "world"}`.
  */
-export interface ByteView<Data> extends Uint8Array<ArrayBuffer>, Phantom<Data> {}
+export interface ByteView<Data, B extends ArrayBufferLike = ArrayBufferLike> extends Uint8Array<B>, Phantom<Data> {}
 
 /**
  * Similar to ByteView but extends ArrayBuffer.

--- a/src/block/interface.ts
+++ b/src/block/interface.ts
@@ -10,7 +10,7 @@ import type { Link, Version } from '../link/interface.ts'
  * For example, a `ByteView<{ hello: "world" }>` is a `Uint8Array` containing a
  * binary representation of a `{hello: "world"}`.
  */
-export interface ByteView<Data> extends Uint8Array, Phantom<Data> {}
+export interface ByteView<Data> extends Uint8Array<ArrayBuffer>, Phantom<Data> {}
 
 /**
  * Similar to ByteView but extends ArrayBuffer.

--- a/src/codecs/json.ts
+++ b/src/codecs/json.ts
@@ -6,7 +6,7 @@ const textDecoder = new TextDecoder()
 export const name = 'json'
 export const code = 0x0200
 
-export function encode <T> (node: T): ByteView<T> {
+export function encode <T> (node: T): ByteView<T, ArrayBuffer> {
   return textEncoder.encode(JSON.stringify(node))
 }
 

--- a/src/codecs/raw.ts
+++ b/src/codecs/raw.ts
@@ -4,7 +4,7 @@ import type { ArrayBufferView, ByteView } from './interface.ts'
 export const name = 'raw'
 export const code = 0x55
 
-export function encode (node: Uint8Array): ByteView<Uint8Array> {
+export function encode (node: Uint8Array): ByteView<Uint8Array<ArrayBuffer>, ArrayBuffer> {
   return coerce(node)
 }
 

--- a/src/varint.ts
+++ b/src/varint.ts
@@ -5,7 +5,7 @@ export function decode (data: Uint8Array, offset = 0): [number, number] {
   return [code, varint.decode.bytes]
 }
 
-export function encodeTo (int: number, target: Uint8Array, offset = 0): Uint8Array {
+export function encodeTo <T extends ArrayBufferLike> (int: number, target: Uint8Array<T>, offset = 0): Uint8Array<T> {
   varint.encode(int, target, offset)
   return target
 }

--- a/src/vendor/varint.d.ts
+++ b/src/vendor/varint.d.ts
@@ -10,7 +10,7 @@ interface Varint {
          * Encodes `num` into `buffer` starting at `offset`. returns `buffer`, with the encoded varint written into it.
          * `varint.encode.bytes` will now be set to the number of bytes modified.
          */
-        (num: number, buffer: Uint8Array, offset?: number): Buffer;
+        <T extends ArrayBufferLike> (num: number, buffer: Uint8Array<T>, offset?: number): Uint8Array<T>;
 
         /**
          * Encodes `num` into `array` starting at `offset`. returns `array`, with the encoded varint written into it.

--- a/test/test-multicodec.spec.ts
+++ b/test/test-multicodec.spec.ts
@@ -15,7 +15,6 @@ describe('multicodec', () => {
   it('encode/decode raw arraybuffer', () => {
     const buff = raw.encode(bytes.fromString('test'))
     assert.deepStrictEqual(buff, bytes.fromString('test'))
-    // @ts-expect-error
     assert.deepStrictEqual(raw.decode(buff.buffer), bytes.fromString('test'))
   })
 
@@ -28,7 +27,6 @@ describe('multicodec', () => {
   it('encode/decode json arraybuffer', () => {
     const buff = json.encode({ hello: 'world' })
     assert.deepStrictEqual(buff, bytes.fromString(JSON.stringify({ hello: 'world' })))
-    // @ts-expect-error
     assert.deepStrictEqual(json.decode(buff.buffer), { hello: 'world' })
   })
 


### PR DESCRIPTION
Allow users to be explicit about the backing type as onward APIs often require ArrayBuffers since the types for ArrayBuffer and SharedArrayBuffer diverged.